### PR TITLE
Fix TensorFlow install requirements in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     only:
         - master
         - dev
-        - tensorflow_install
 
 dist: trusty
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
     only:
         - master
         - dev
+        - tensorflow_install
 
 dist: trusty
 sudo: false
@@ -40,7 +41,7 @@ install:
 
     # for test pypi add dependency installs manually
     # - pip install --index-url --no-deps https://test.pypi.org/simple sktime_dl==0.2.dev1
-    - pip install sktime-dl
+    - pip install .
     - python setup.py build_ext -i
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ def find_install_requires():
     has_tf = False
 
     if working_set.find(Requirement.parse('tensorflow')) is not None:
-            has_tf = True
+        has_tf = True
 
     if working_set.find(Requirement.parse('tensorflow-gpu')) is not None:
-            has_tf_gpu = True
+        has_tf_gpu = True
 
     if has_tf_gpu:
         # Specify tensorflow-gpu version if it is already installed.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ import os
 import re
 import sys
 import platform
-from packaging import version
+from pkg_resources import Requirement
+from pkg_resources import working_set
 
 try:
     import numpy as np
@@ -44,27 +45,40 @@ def find_version(*file_paths):
 
 
 def find_install_requires():
-	'''Return a list of dependencies. 
-	
-	tensorflow>=1.8.0 and/or tensorflow-gpu 1.8.0 is required. If not 
-	found, then tensorflow>=1.8.0 is added to the install_requires list.
-	'''
-	install_tf = True
-	tf_version_required = '1.8.0'
-	try:
-		import tensorflow as tf
-		install_tf = version.parse(tf.__version__) < version.parse(tf_version_required)
-	except:
-		pass
-	install_requires = [
-		# 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
-		# 'keras_contrib', # use once keras_contrib is available on pypi
-		'sktime>=0.3.0',
-		'keras>=2.2.4'
-	]
-	if install_tf:
-		install_requires.append('tensorflow>='+tf_version_required)
-	return install_requires
+    '''Return a list of dependencies.
+
+    A supported version of tensorflow and/or tensorflow-gpu is required. If not 
+    found, then tensorflow is added to the install_requires list.
+    '''
+    # tensorflow version requirements
+    version_start = '1.8.0'
+    version_end = '2'
+
+    install_requires = [
+        # 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
+        # 'keras_contrib', # use once keras_contrib is available on pypi
+        'sktime>=0.3.0',
+        'keras>=2.2.4'
+    ]
+    
+    has_tf_gpu = False
+    has_tf = False
+
+    if working_set.find(Requirement.parse('tensorflow')) is not None:
+            has_tf = True
+
+    if working_set.find(Requirement.parse('tensorflow-gpu')) is not None:
+            has_tf_gpu = True
+
+    if has_tf_gpu:
+        # Specify tensorflow-gpu version if it is already installed.
+        install_requires.append('tensorflow-gpu>='+version_start+',<'+version_end)
+    if has_tf or not has_tf_gpu:
+        # If tensorflow-gpu is not installed, then install tensorflow because
+        # it includes GPU support from 1.15 onwards.
+        install_requires.append('tensorflow>='+version_start+',<'+version_end)
+
+    return install_requires
 
 
 DISTNAME = 'sktime-dl'  # package name is sktime-dl, to have a valid module path, module name is sktime_dl
@@ -84,8 +98,6 @@ PROJECT_URLS = {
 }
 VERSION = find_version('sktime_dl', '__init__.py')
 INSTALL_REQUIRES = find_install_requires()
-
-
 CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Intended Audience :: Developers',
                'License :: OSI Approved',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import platform
+from packaging import version
 
 try:
     import numpy as np
@@ -42,6 +43,30 @@ def find_version(*file_paths):
         raise RuntimeError("Unable to find version string.")
 
 
+def find_install_requires():
+	'''Return a list of dependencies. 
+	
+	tensorflow>=1.8.0 and/or tensorflow-gpu 1.8.0 is required. If not 
+	found, then tensorflow>=1.8.0 is added to the install_requires list.
+	'''
+	install_tf = True
+	tf_version_required = '1.8.0'
+	try:
+		import tensorflow as tf
+		install_tf = version.parse(tf.__version__) < version.parse(tf_version_required)
+	except:
+		pass
+	install_requires = [
+		# 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
+		# 'keras_contrib', # use once keras_contrib is available on pypi
+		'sktime>=0.3.0',
+		'keras>=2.2.4'
+	]
+	if install_tf:
+		install_requires.append('tensorflow>='+tf_version_required)
+	return install_requires
+
+
 DISTNAME = 'sktime-dl'  # package name is sktime-dl, to have a valid module path, module name is sktime_dl
 DESCRIPTION = 'Deep learning extension package for sktime, a scikit-learn compatible toolbox for ' \
               'learning with time series data'
@@ -58,13 +83,9 @@ PROJECT_URLS = {
     'Source Code': 'https://github.com/uea-machine-learning/sktime-dl'
 }
 VERSION = find_version('sktime_dl', '__init__.py')
-INSTALL_REQUIRES = [
-    # 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
-    # 'keras_contrib', # use once keras_contrib is available on pypi
-    'sktime>=0.3.0',
-    'keras>=2.2.4',
-    'tensorflow>=1.8.0'  # and/or tensorflow-gpu 1.8.0
-]
+INSTALL_REQUIRES = find_install_requires()
+
+
 CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Intended Audience :: Developers',
                'License :: OSI Approved',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the extension guidelines: https://github.com/uea-machine-learning/sktime-dl/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
A fix related to the comment in pull request 14 "0.2.0 proposal" regarding TensorFlow installation.


#### What does this implement/fix? Explain your changes.
A fix related to the comment in pull request 14 "0.2.0 proposal":
"_Currently, tensorflow >=1.8 is set to be installed, which will install 2.x. This would ideally be >=1.8 and <2. Also, if there's a way to check for the installation of tensorflow OR tensorflow-gpu, that'd be decent._ "

Change made to setup.py so that if tensorflow-gpu is already installed, then setup.py specifies that its version must be >=1.8.0 and <2. 
Similarly, if tensorflow is already installed then its version must be >=1.8.0 and <2. 
If neither is installed then setup.py requires tensorflow >=1.8.0 and <2 to be installed. This will almost certainly install tensorflow >=1.15, which includes GPU support.


#### Any other comments?
Change made to Travis build to install sktime-dl from the local project directory instead of from PyPi.

#### Next steps
I'd like to contribute further. Perhaps starting by working on compatibility with TensorFlow 2? 