### PR TITLE
Tensorflow v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
     - conda create -n testenv --yes python=$PYTHON_VERSION pip
     - source activate testenv
     - conda install -n testenv --yes pip numpy=$NUMPY_VERSION cython nose pytest pytest-cov sphinx jupyter
-    - pip install tensorflow=$TF_VERSION
+    - pip install tensorflow==$TF_VERSION
     - pip install sphinx_rtd_theme
     - pip install nbsphinx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     - pip install tensorflow==$TF_VERSION
     - pip install sphinx_rtd_theme
     - pip install nbsphinx
-    - pip install coveralls==1.10.0
+    - pip install coveralls
 
     # install keras contrib manually as currently not available on pypi
     - pip install git+https://github.com/keras-team/keras-contrib.git@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
     only:
         - master
         - dev
+        - tensorflow_v2
 
 dist: trusty
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     include:
         # add more combinations here as per requirement
         - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="1.15"
-        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="2.0"
+        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="2.1"
 
 install:
     # install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     only:
         - master
         - dev
-        - tensorflow_v2
 
 dist: trusty
 sudo: false
@@ -18,7 +17,7 @@ matrix:
     include:
         # add more combinations here as per requirement
         - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="1.15"
-        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="2.1"
+        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="2.0"
 
 install:
     # install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ script:
     - cd for_test
     - pytest -v --cov=sktime_dl --pyargs ../sktime_dl
 
+after_success:
+    - coveralls
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
     - pip install tensorflow==$TF_VERSION
     - pip install sphinx_rtd_theme
     - pip install nbsphinx
+    - pip install coveralls==1.10.0
 
     # install keras contrib manually as currently not available on pypi
     - pip install git+https://github.com/keras-team/keras-contrib.git@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     only:
         - master
         - dev
-        - tensorflow_v2
 
 dist: trusty
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
     only:
         - master
         - dev
+        - tensorflow_v2
 
 dist: trusty
 sudo: false
@@ -16,7 +17,8 @@ cache:
 matrix:
     include:
         # add more combinations here as per requirement
-        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16"
+        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="1.15"
+        - env: PYTHON_VERSION="3.6" NUMPY_VERSION="1.16" TF_VERSION="2.0"
 
 install:
     # install miniconda
@@ -31,6 +33,7 @@ install:
     - conda create -n testenv --yes python=$PYTHON_VERSION pip
     - source activate testenv
     - conda install -n testenv --yes pip numpy=$NUMPY_VERSION cython nose pytest pytest-cov sphinx jupyter
+    - pip install tensorflow=$TF_VERSION
     - pip install sphinx_rtd_theme
     - pip install nbsphinx
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ sktime-dl is under development. To guarantee that you're using the most up to da
 	
 	pip install git+https://www.github.com/keras-team/keras-contrib.git
 	
-When installing sktime-dl, `Tensorflow <https://www.tensorflow.org/install/>`__ 1.x will be installed as the backend for Keras. Tensorflow 2.x is currently unsupported. Other backends should be usable in principle but are untested.
+When installing sktime-dl, `Tensorflow <https://www.tensorflow.org/install/>`__ 1.x will be installed as the backend for Keras. Tensorflow 2.0 is also supported. Other backends should be usable in principle but are untested.
 	
 With these instructions, the networks can be run on your CPU. If you wish to run the networks on an NVIDIA® GPU, extra drivers and toolkits (GPU drivers, CUDA Toolkit, and CUDNN library) need to be installed separately to sktime-dl. See `this page <https://www.tensorflow.org/install/gpu#software_requirements>`__ for more information.
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ def find_install_requires():
     '''
     # tensorflow version requirements
     version_start = '1.8.0'
-    version_end = '2'
 
     install_requires = [
         # 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
@@ -72,11 +71,11 @@ def find_install_requires():
 
     if has_tf_gpu:
         # Specify tensorflow-gpu version if it is already installed.
-        install_requires.append('tensorflow-gpu>='+version_start+',<'+version_end)
+        install_requires.append('tensorflow-gpu>='+version_start)
     if has_tf or not has_tf_gpu:
         # If tensorflow-gpu is not installed, then install tensorflow because
         # it includes GPU support from 1.15 onwards.
-        install_requires.append('tensorflow>='+version_start+',<'+version_end)
+        install_requires.append('tensorflow>='+version_start)
 
     return install_requires
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 
 # raise warning for Python versions not equal to 3.6
 # TODO find fix for tensorflow interacting with python 3.7, some particular factor of the environment does not work
+# keras is compatible with Python 2.7-3.6
 if sys.version_info < (3, 6) or sys.version_info >= (3, 7):
     raise RuntimeError("sktime-dl requires Python 3.6. The current"
                        " Python version is %s installed in %s."
@@ -57,7 +58,7 @@ def find_install_requires():
         # 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
         # 'keras_contrib', # use once keras_contrib is available on pypi
         'sktime>=0.3.0',
-        'keras>=2.2.4'
+        'keras>=2.3.0'
     ]
     
     has_tf_gpu = False

--- a/sktime_dl/.coveragerc
+++ b/sktime_dl/.coveragerc
@@ -1,7 +1,9 @@
 [run]
 source = sktime_dl/*
-omit = sktime_dl/*/tests/*
+omit = sktime_dl/classifiers/deeplearning/tests/*
+omit = sktime_dl/meta/tests/*
 
 [report]
 include = sktime_dl/*
-omit = sktime_dl/*/tests/*
+omit = sktime_dl/classifiers/deeplearning/tests/*
+omit = sktime_dl/meta/tests/*

--- a/sktime_dl/.coveragerc
+++ b/sktime_dl/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = sktime_dl/*
+omit = sktime_dl/*/tests/*
+
+[report]
+include = sktime_dl/*
+omit = sktime_dl/*/tests/*

--- a/sktime_dl/classifiers/deeplearning/_base.py
+++ b/sktime_dl/classifiers/deeplearning/_base.py
@@ -18,6 +18,8 @@
 
 __author__ = "James Large, Aaron Bostrom"
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 
@@ -97,12 +99,27 @@ class BaseDeepClassifier(BaseClassifier):
 
         return X
 
-    def save_trained_model(self):
+    def save_trained_model(self, save_format='h5'):
+        """
+        Saves the model to an HDF file.
+        
+        Saved models can be reinstantiated via `keras.models.load_model`.
+        Parameters
+        ----------
+        save_format: string
+            'h5'. Defaults to 'h5' currently but future releases
+            will default to 'tf', the TensorFlow SavedModel format.
+        """
+        if save_format is not 'h5':
+            raise ValueError("save_format must be 'h5'. This is the only format currently supported.")
         if self.model_save_directory is not None:
             if self.model_name is None:
-                self.model.save(self.model_save_directory + 'trained_model.hdf5')
+                file_name = 'trained_model.hdf5'
             else:
-                self.model.save(self.model_save_directory + self.model_name + '.hdf5')
+                file_name = self.model_name + '.hdf5'
+            path = Path(self.model_save_directory) / file_name
+            self.model.save(path) # Add save_format here upon migration from keras to tf.keras
+
 
     def convert_y(self, y):
         self.label_encoder = LabelEncoder()

--- a/sktime_dl/meta/_dlensemble.py
+++ b/sktime_dl/meta/_dlensemble.py
@@ -38,10 +38,9 @@ class DeepLearnerEnsembleClassifier(BaseClassifier):
                  base_model=InceptionTimeClassifier(),
                  nb_iterations=5,
                  keep_in_memory=False,
-
                  random_seed=0,
                  verbose=False,
-                 model_name="InceptionTime",
+                 model_name=None,
                  model_save_directory=None):
         '''
         :param base_model: an implementation of BaseDeepLearner, the model to ensemble over. 

--- a/sktime_dl/meta/_dlensemble.py
+++ b/sktime_dl/meta/_dlensemble.py
@@ -6,6 +6,8 @@ import os
 import keras
 import gc
 
+from pathlib import Path
+
 from keras.models import load_model
 
 from sklearn.utils.multiclass import class_distribution
@@ -172,7 +174,8 @@ class DeepLearnerEnsembleClassifier(BaseClassifier):
             if self.keep_in_memory:
                 keras_model = skdl_model.model
             else:
-                keras_model = load_model(self.model_save_directory + skdl_model + '.hdf5')
+                keras_model = load_model(
+                    Path(self.model_save_directory) / (skdl_model + '.hdf5'))
 
             # keras models' predict is same as what we/sklearn means by predict_proba, i.e. give prob distributions
             probs = probs + keras_model.predict(X, **kwargs)

--- a/sktime_dl/meta/tests/test_ensembling.py
+++ b/sktime_dl/meta/tests/test_ensembling.py
@@ -35,7 +35,7 @@ def test_basic_saving(network=DeepLearnerEnsembleClassifier(
             base_model=CNNClassifier(nb_epochs=50),
             nb_iterations=2,
             keep_in_memory=False,
-            model_save_directory="testResultsDELETE/",
+            model_save_directory="testResultsDELETE",
             verbose=True)):
     '''
     just a super basic test with gunpoint,

--- a/sktime_dl/meta/tests/test_ensembling.py
+++ b/sktime_dl/meta/tests/test_ensembling.py
@@ -57,8 +57,8 @@ def test_basic_saving(network=DeepLearnerEnsembleClassifier(
 
     print(network.score(X_test[:10], y_test[:10]))
 
-    Path(path / (network.base_model.model_name + "_0.hdf5")).unlink() # delete file
-    Path(path / (network.base_model.model_name + "_1.hdf5")).unlink() # delete file
+    (path / (network.base_model.model_name + "_0.hdf5")).unlink() # delete file
+    (path / (network.base_model.model_name + "_1.hdf5")).unlink() # delete file
     path.rmdir() # directory should now be empty, fails if not
 
     print("End test_basic()")

--- a/sktime_dl/meta/tests/test_ensembling.py
+++ b/sktime_dl/meta/tests/test_ensembling.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from sktime.datasets import load_italy_power_demand
 from sktime_dl.meta import DeepLearnerEnsembleClassifier
@@ -47,18 +47,19 @@ def test_basic_saving(network=DeepLearnerEnsembleClassifier(
 
     print("Start test_basic()")
 
-    os.mkdir(network.model_save_directory)
+    path = Path(network.model_save_directory)
+    path.mkdir()
 
     X_train, y_train = load_italy_power_demand(split='TRAIN', return_X_y=True)
     X_test, y_test = load_italy_power_demand(split='TEST', return_X_y=True)
 
-    hist = network.fit(X_train[:10], y_train[:10])
+    __ = network.fit(X_train[:10], y_train[:10])
 
     print(network.score(X_test[:10], y_test[:10]))
 
-    os.remove(os.path.join(network.model_save_directory, network.base_model.model_name + "_0.hdf5"))
-    os.remove(os.path.join(network.model_save_directory, network.base_model.model_name + "_1.hdf5"))
-    os.rmdir(network.model_save_directory) # directory should now be empty, fails if not
+    Path(path / (network.base_model.model_name + "_0.hdf5")).unlink() # delete file
+    Path(path / (network.base_model.model_name + "_1.hdf5")).unlink() # delete file
+    path.rmdir() # directory should now be empty, fails if not
 
     print("End test_basic()")
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16
TensorFlow 2 compatibility


#### What does this implement/fix? Explain your changes.

Enable use of TensorFlow 2.0 as a backend.

Added a second build to Travis so there is one that installs TensorFlow 1.15 and one that installs 2.0. These builds run and test fine on my fork. 

Added coveralls to the Travis build in order to view line coverage at coveralls.io. The tests cover 87% of the code and the lines that aren’t covered aren't novel calls to TensorFlow. 

Removed the restriction in setup.py that required install of tensorflow<2 (the restriction was added only a few days ago). Changed setup.py to require install of keras>=2.3.0 because 2.3 is the only version that supports TensorFlow 2.

TensorFlow’s tf_upgrade_v2 script highlighted only one possible issue (regarding model.save) but it is not an issue for sktime-dl because it is using keras, not tf.keras. However, I updated save_trained_model in anticipation of needing to migrate from keras to tf.keras (keras won’t be maintained after April 2020). The default format for saving a tf.keras model switches from h5 in TF1 to TensorFlow SavedModel in TF2. I added the same “save_format” input to save_trained_model and highlighted this potential future change in the function’s docstring.

Switched save_trained_model from using os to pathlib to handle file paths. Now the user can enter model_save_directory with or without the trailing forward slash. Furthermore, pathlib supports Windows and Posix paths. 

Ensemble model – corrected the default model_name - previously it was “InceptionTime”.

#### Any other comments?
Next steps :
+ TensorFlow 2.1 was released on 8 Jan so I’ll start testing this with a view to update next week.
+ Consider migrating from keras to tf.keras – I’ll open an issue.