### PR TITLE
MCDCNN intermittent failure resolved. Added TWIESN to accuracy tests,…

### DIFF
--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -149,11 +149,9 @@ class MCDCNNClassifier(BaseDeepClassifier):
         """
         X = self.check_and_clean_data(X, y, input_checks=input_checks)
 
-        x_train, x_val, y_train, y_val = \
-            train_test_split(X, y, test_size=0.33)
-
-        y_train_onehot = self.convert_y(y_train)
-        y_val_onehot = self.convert_y(y_val)
+        y_onehot = self.convert_y(y)
+        x_train, x_val, y_train_onehot, y_val_onehot = \
+            train_test_split(X, y_onehot, test_size=0.33)
 
         x_train = self.prepare_input(x_train)
         x_val = self.prepare_input(x_val)

--- a/sktime_dl/deeplearning/tests/test_accuracy.py
+++ b/sktime_dl/deeplearning/tests/test_accuracy.py
@@ -96,7 +96,6 @@ def test_tlenet_accuracy():
     accuracy_test(network=TLENETClassifier(), lower=0.90)
 
 
-@pytest.mark.skip(reason="TWIESN accuracy is 0.49 whilst dl-4-tsc accuracy is 0.88.")
 @flaky(max_runs=3, rerun_filter=is_not_value_error)
 def test_twiesn_accuracy(): 
     accuracy_test(network=TWIESNClassifier(), lower=0.88-2*0.022)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the intermittent failure of the test on MCDCNN.
Issue mentioned in PR #22  

#### What does this implement/fix? Explain your changes.
The MCDCNN failure was _“ValueError: Error when checking target: expected dense_9 to have shape (1,) but got array with shape (2,)”_

The failure occured because the test uses only 10 data samples for training and MCDCNN further splits this into 6 training and 4 validation samples. The split is random and sometimes all 6 training samples are the same class. As a result, the y onehot input could be of shape (1,) instead of (2,). 

The change implemented instead performs the conversion from y to y onehot before doing the ```train_test_split```.


#### Any other comments?
Also enabled the accuracy test on TWIESN, following @James-Large earlier commit. Its accuracy is now the same as that reported in dl-4-tsc.

The accuracy tests are still marked as ‘slow’ so they don’t run in the Travis build.