### PR TITLE
Callbacks

### DIFF
--- a/sktime_dl/deeplearning/cnn/_classifier.py
+++ b/sktime_dl/deeplearning/cnn/_classifier.py
@@ -35,6 +35,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
                  nb_conv_layers=2,
                  filter_sizes=[6, 12],
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="cnn",
@@ -64,7 +65,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
         self.verbose = verbose
         self.is_fitted_ = False
 
-        self.callbacks = []
+        self.callbacks = callbacks
 
         self.input_shape = None
         self.history = None

--- a/sktime_dl/deeplearning/cnn/_classifier.py
+++ b/sktime_dl/deeplearning/cnn/_classifier.py
@@ -35,7 +35,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
                  nb_conv_layers=2,
                  filter_sizes=[6, 12],
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="cnn",
@@ -66,7 +66,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
         self.verbose = verbose
         self.is_fitted_ = False
 
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
         self.input_shape = None
         self.history = None

--- a/sktime_dl/deeplearning/cnn/_classifier.py
+++ b/sktime_dl/deeplearning/cnn/_classifier.py
@@ -57,6 +57,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
         :param avg_pool_size: int, size of the average pooling windows
         :param nb_conv_layers: int, the number of convolutional plus average pooling layers
         :param filter_sizes: int, array of shape = (nb_conv_layers)
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -57,6 +57,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
         :param avg_pool_size: int, size of the average pooling windows
         :param nb_conv_layers: int, the number of convolutional plus average pooling layers
         :param filter_sizes: int, array of shape = (nb_conv_layers)
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -35,7 +35,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
                  nb_conv_layers=2,
                  filter_sizes=[6, 12],
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="cnn_regressor",
@@ -66,7 +66,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
         self.verbose = verbose
         self.is_fitted_ = False
 
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
         self.input_shape = None
         self.history = None

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -34,6 +34,8 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
                  avg_pool_size=3,
                  nb_conv_layers=2,
                  filter_sizes=[6, 12],
+
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="cnn_regressor",
@@ -63,7 +65,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
         self.verbose = verbose
         self.is_fitted_ = False
 
-        self.callbacks = []
+        self.callbacks = callbacks
 
         self.input_shape = None
         self.history = None

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -2,7 +2,7 @@ __author__ = "James Large"
 
 from tensorflow import keras
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.encoder._base import EncoderNetwork
 
 

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -29,6 +29,7 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
                  nb_epochs=100,
                  batch_size=12,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="encoder",
@@ -56,7 +57,7 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """
@@ -77,8 +78,6 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
 
         model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.Adam(0.00001),
                       metrics=['accuracy'])
-
-        self.callbacks = []
 
         return model
 

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -29,7 +29,7 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
                  nb_epochs=100,
                  batch_size=12,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="encoder",
@@ -58,7 +58,7 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -41,6 +41,7 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -29,6 +29,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="encoder_regressor",
@@ -55,7 +56,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -41,6 +41,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -29,7 +29,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="encoder_regressor",
@@ -57,7 +57,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -29,7 +29,7 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="fcn",
@@ -58,7 +58,7 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -29,6 +29,7 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="fcn",
@@ -56,7 +57,7 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """
@@ -79,10 +80,11 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
         model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
-                                                      min_lr=0.0001)
-
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -41,6 +41,7 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -2,7 +2,7 @@ __author__ = "James Large"
 
 from tensorflow import keras
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.fcn._base import FCNNetwork
 
 

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -29,7 +29,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="fcn_regressor",
@@ -57,7 +57,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -29,6 +29,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="fcn_regressor",
@@ -55,7 +56,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, **kwargs):
         """
@@ -76,10 +77,11 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         model.compile(loss='mean_squared_error', optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
-                                                      min_lr=0.0001)
-
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -41,6 +41,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         '''    
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -31,7 +31,7 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
                  batch_size=64,
                  nb_epochs=1500,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="inception",
@@ -73,7 +73,7 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
         # calced in fit
         self.input_shape = None
         self.history = None
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -57,6 +57,7 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
         :param batch_size: int, the number of samples per gradient update.
         :param bottleneck_size: int,
         :param nb_epochs: int, the number of epochs to train the model
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -1,6 +1,6 @@
 from tensorflow import keras
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.inceptiontime._base import InceptionTimeNetwork
 
 

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -31,6 +31,7 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
                  batch_size=64,
                  nb_epochs=1500,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="inception",
@@ -71,7 +72,7 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
         # calced in fit
         self.input_shape = None
         self.history = None
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """
@@ -94,10 +95,11 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
         model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
-                                                      min_lr=0.0001)
-
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -32,6 +32,8 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
                  kernel_size=41 - 1,
                  batch_size=64,
                  nb_epochs=1500,
+
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="inception_regressor",
@@ -73,7 +75,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         # calced in fit
         self.input_shape = None
         self.history = None
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, **kwargs):
         """
@@ -93,9 +95,11 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         model.compile(loss='mean_squared_error', optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(
-            monitor='loss', factor=0.5, patience=50, min_lr=0.0001)
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -33,7 +33,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
                  batch_size=64,
                  nb_epochs=1500,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="inception_regressor",
@@ -76,7 +76,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         # calced in fit
         self.input_shape = None
         self.history = None
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -59,6 +59,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         :param batch_size: int, the number of samples per gradient update.
         :param bottleneck_size: int,
         :param nb_epochs: int, the number of epochs to train the model
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sklearn.model_selection import train_test_split
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 
 
 class MCDCNNClassifier(BaseDeepClassifier):

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -31,6 +31,7 @@ class MCDCNNClassifier(BaseDeepClassifier):
                  nb_epochs=120,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="mcdcnn",
@@ -59,6 +60,7 @@ class MCDCNNClassifier(BaseDeepClassifier):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
+        self.callbacks = callbacks
 
         self.random_seed = random_seed
         self.random_state = np.random.RandomState(self.random_seed)

--- a/sktime_dl/deeplearning/mcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcnn/_classifier.py
@@ -10,7 +10,7 @@ import gc
 
 from sklearn.model_selection import train_test_split
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 
 
 class MCNNClassifier(BaseDeepClassifier):

--- a/sktime_dl/deeplearning/mlp/_classifier.py
+++ b/sktime_dl/deeplearning/mlp/_classifier.py
@@ -41,6 +41,7 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/mlp/_classifier.py
+++ b/sktime_dl/deeplearning/mlp/_classifier.py
@@ -29,6 +29,7 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
                  nb_epochs=5000,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="mlp",
@@ -56,7 +57,7 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """
@@ -78,9 +79,11 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
         model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.Adadelta(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=200, min_lr=0.1)
-
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/mlp/_classifier.py
+++ b/sktime_dl/deeplearning/mlp/_classifier.py
@@ -29,7 +29,7 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
                  nb_epochs=5000,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="mlp",
@@ -58,7 +58,7 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -29,7 +29,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="mlp_regressor",
@@ -57,7 +57,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -41,6 +41,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, the number of samples per gradient update.
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -29,6 +29,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
                  nb_epochs=2000,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="mlp_regressor",
@@ -55,7 +56,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, **kwargs):
         """
@@ -74,9 +75,11 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         model.compile(loss='mean_squared_error', optimizer=keras.optimizers.Adadelta(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=200, min_lr=0.1)
-
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -29,6 +29,7 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
                  nb_epochs=1500,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="resnet",
@@ -56,7 +57,7 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """
@@ -79,13 +80,11 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50, min_lr=0.0001)
-
-        # file_path = self.output_directory + 'best_model.hdf5'
-        # model_checkpoint = keras.callbacks.ModelCheckpoint(filepath=file_path, monitor='loss',
-        #                                                   save_best_only=True)
-        # self.callbacks = [reduce_lr, model_checkpoint]
-        self.callbacks = [reduce_lr]
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
         return model
 

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -41,6 +41,7 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -29,7 +29,7 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
                  nb_epochs=1500,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="resnet",
@@ -58,7 +58,7 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -2,7 +2,7 @@ __author__ = "James Large"
 
 from tensorflow import keras
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.resnet._base import ResNetNetwork
 
 

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -29,6 +29,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
                  nb_epochs=1500,
                  batch_size=16,
 
+                 callbacks=[],
                  random_seed=0,
                  verbose=False,
                  model_name="resnet_regressor",
@@ -56,7 +57,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = None
+        self.callbacks = callbacks
 
     def build_model(self, input_shape, **kwargs):
         """
@@ -79,15 +80,19 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         model.compile(loss='mean_squared_error', optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
 
-        reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50, min_lr=0.0001)
+        # if user hasn't provided a custom ReduceLROnPlateau via init already, add the default from literature
+        if not any(isinstance(callback, keras.callbacks.ReduceLROnPlateau) for callback in self.callbacks):
+            reduce_lr = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.5, patience=50,
+                                                          min_lr=0.0001)
+            self.callbacks.append(reduce_lr)
 
+        # todo could be moved out no that things are passed via init? raises argument of defining common/generic callbacks
+        # in base classes
         if save_best_model:
             file_path = self.model_save_directory + 'best_model.hdf5'
             model_checkpoint = keras.callbacks.ModelCheckpoint(
                 filepath=file_path, monitor='loss', save_best_only=True)
-            self.callbacks = [reduce_lr, model_checkpoint]
-        else:
-            self.callbacks = [reduce_lr]
+            self.callbacks.append(model_checkpoint)
 
         return model
 

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -41,6 +41,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -29,7 +29,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
                  nb_epochs=1500,
                  batch_size=16,
 
-                 callbacks=[],
+                 callbacks=None,
                  random_seed=0,
                  verbose=False,
                  model_name="resnet_regressor",
@@ -58,7 +58,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         # predefined
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/tests/test_dl4tscnetworks.py
+++ b/sktime_dl/deeplearning/tests/test_dl4tscnetworks.py
@@ -12,7 +12,7 @@ from sktime_dl.deeplearning import TWIESNClassifier
 from sktime_dl.deeplearning import InceptionTimeClassifier
 
 
-def test_basic_univariate(network=CNNClassifier(nb_epochs=50)):
+def test_basic_univariate(network=CNNClassifier(nb_epochs=10)):
     '''
     just a super basic test with gunpoint,
         load data,
@@ -32,7 +32,7 @@ def test_basic_univariate(network=CNNClassifier(nb_epochs=50)):
     print("End test_basic()")
 
 
-def test_pipeline(network=CNNClassifier(nb_epochs=50)):
+def test_pipeline(network=CNNClassifier(nb_epochs=10)):
     '''
     slightly more generalised test with sktime pipelines
         load data,
@@ -61,7 +61,7 @@ def test_pipeline(network=CNNClassifier(nb_epochs=50)):
     print("End test_pipeline()")
 
 
-def test_highLevelsktime(network=CNNClassifier(nb_epochs=50)):
+def test_highLevelsktime(network=CNNClassifier(nb_epochs=10)):
     '''
     truly generalised test with sktime tasks/strategies
         load data, build task
@@ -111,16 +111,16 @@ def test_highLevelsktime(network=CNNClassifier(nb_epochs=50)):
 
 def test_all_networks():
     networks = [
-        CNNClassifier(nb_epochs=50),
-        EncoderClassifier(nb_epochs=50),
-        FCNClassifier(nb_epochs=50),
-        MCDCNNClassifier(nb_epochs=50),
-        MCNNClassifier(nb_epochs=50),
-        MLPClassifier(nb_epochs=50),
-        ResNetClassifier(nb_epochs=50),
-        TLENETClassifier(nb_epochs=50),
+        CNNClassifier(nb_epochs=10),
+        EncoderClassifier(nb_epochs=10),
+        FCNClassifier(nb_epochs=10),
+        MCDCNNClassifier(nb_epochs=10),
+        MCNNClassifier(nb_epochs=10),
+        MLPClassifier(nb_epochs=10),
+        ResNetClassifier(nb_epochs=10),
+        TLENETClassifier(nb_epochs=10),
         TWIESNClassifier(),
-        InceptionTimeClassifier(nb_epochs=50),
+        InceptionTimeClassifier(nb_epochs=10),
     ]
 
     for network in networks:
@@ -128,7 +128,7 @@ def test_all_networks():
         test_basic_univariate(network)
         # test_basic_multivariate(network)
         # test_pipeline(network)
-        # test_highLevelsktime(network)
+        test_highLevelsktime(network)
         print('\t\t' + network.__class__.__name__ + ' testing finished')
 
 

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -3,7 +3,7 @@ __author__ = "Aaron Bostrom, James Large"
 from tensorflow import keras
 import numpy as np
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.tlenet._base import TLENETNetwork
 
 

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -28,7 +28,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
                  nb_epochs=1000,
                  batch_size=256,
 
-                 callbacks=[],
+                 callbacks=None,
                  verbose=False,
                  random_seed=0,
                  model_name="tlenet",
@@ -52,7 +52,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
         # calced in fit
         self.input_shape = None

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -40,6 +40,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -28,6 +28,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
                  nb_epochs=1000,
                  batch_size=256,
 
+                 callbacks=[],
                  verbose=False,
                  random_seed=0,
                  model_name="tlenet",
@@ -50,6 +51,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
+        self.callbacks = callbacks
 
         # calced in fit
         self.input_shape = None
@@ -75,13 +77,6 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         model.compile(optimizer=keras.optimizers.Adam(lr=0.01, decay=0.005),
                       loss='categorical_crossentropy', metrics=['accuracy'])
 
-        # file_path = self.output_directory+'best_model.hdf5'
-
-        # model_checkpoint = keras.callbacks.ModelCheckpoint(filepath=file_path, monitor='loss',
-        # save_best_only=True)
-
-        self.callbacks = []
-
         return model
 
     def fit(self, X, y, input_checks=True, **kwargs):
@@ -106,9 +101,6 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         self.adjust_parameters(X)
         X, y, tot_increase_num = self.pre_processing(X, y)
-        # print(y.shape)
-
-        # print('Total increased number for each MTS: ', tot_increase_num)
 
         input_shape = X.shape[1:]  # pylint: disable=E1136  # pylint/issues/3139
         self.model = self.build_model(input_shape, self.nb_classes)

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -30,7 +30,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
                  nb_epochs=1000,
                  batch_size=256,
 
-                 callbacks=[],
+                 callbacks=None,
                  verbose=False,
                  random_seed=0,
                  model_name="tlenet_regressor",
@@ -54,7 +54,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
 
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
-        self.callbacks = callbacks
+        self.callbacks = callbacks if callbacks is not None else []
 
         # calced in fit
         self.input_shape = None

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -29,6 +29,8 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
     def __init__(self,
                  nb_epochs=1000,
                  batch_size=256,
+
+                 callbacks=[],
                  verbose=False,
                  random_seed=0,
                  model_name="tlenet_regressor",
@@ -51,6 +53,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
 
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
+        self.callbacks = callbacks
 
         # calced in fit
         self.input_shape = None
@@ -80,9 +83,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
             file_path = self.model_save_directory + 'best_model.hdf5'
             model_checkpoint = keras.callbacks.ModelCheckpoint(
                 filepath=file_path, monitor='loss', save_best_only=True)
-            self.callbacks = [model_checkpoint]
-        else:
-            self.callbacks = []
+            self.callbacks.append(model_checkpoint)
 
         return model
 

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -42,6 +42,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         '''
         :param nb_epochs: int, the number of epochs to train the model
         :param batch_size: int, specifying the length of the 1D convolution window
+        :param callbacks: list of tf.keras.callbacks.Callback objects
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information
         :param model_name: string, the name of this model for printing and file writing purposes

--- a/sktime_dl/deeplearning/twiesn/_classifier.py
+++ b/sktime_dl/deeplearning/twiesn/_classifier.py
@@ -9,7 +9,7 @@ from sklearn.linear_model import Ridge
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 
 
 class TWIESNClassifier(BaseDeepClassifier):

--- a/sktime_dl/meta/_dlensemble.py
+++ b/sktime_dl/meta/_dlensemble.py
@@ -82,7 +82,7 @@ class DeepLearnerEnsembleClassifier(BaseClassifier):
         self.random_seed = random_seed
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def construct_model(self, itr):
+    def _construct_model(self, itr):
         model = clone(self.base_model)
         model.random_seed = self.random_seed + itr
 
@@ -196,6 +196,9 @@ class EnsembleFromFileClassifier(BaseClassifier):
     '''
     A simple utility for post-hoc ensembling over the results of networks that have already been trained and had their results
     saved via sktime.contrib.experiments.py
+
+    Note that there will be faulty edge cases with this, e.g. if the build process using this is naively timed, only the
+    file read and prediction averaging will be taken in to consideration, not the actual network training
     '''
 
     def __init__(self,
@@ -220,7 +223,7 @@ class EnsembleFromFileClassifier(BaseClassifier):
         self.random_seed = random_seed
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def load_network_probs(self, network_name, itr, res_path, dataset_name, fold):
+    def _load_network_probs(self, network_name, itr, res_path, dataset_name, fold):
         path = os.path.join(res_path, network_name + str(itr), "Predictions", dataset_name,
                             "testFold" + str(fold) + ".csv")
         probs = pd.read_csv(path, engine='python', skiprows=3, header=None)

--- a/sktime_dl/meta/_dlensemble.py
+++ b/sktime_dl/meta/_dlensemble.py
@@ -82,7 +82,7 @@ class DeepLearnerEnsembleClassifier(BaseClassifier):
         self.random_seed = random_seed
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def _construct_model(self, itr):
+    def construct_model(self, itr):
         model = clone(self.base_model)
         model.random_seed = self.random_seed + itr
 
@@ -223,7 +223,7 @@ class EnsembleFromFileClassifier(BaseClassifier):
         self.random_seed = random_seed
         self.random_state = np.random.RandomState(self.random_seed)
 
-    def _load_network_probs(self, network_name, itr, res_path, dataset_name, fold):
+    def load_network_probs(self, network_name, itr, res_path, dataset_name, fold):
         path = os.path.join(res_path, network_name + str(itr), "Predictions", dataset_name,
                             "testFold" + str(fold) + ".csv")
         probs = pd.read_csv(path, engine='python', skiprows=3, header=None)

--- a/sktime_dl/meta/_dltuner.py
+++ b/sktime_dl/meta/_dltuner.py
@@ -35,7 +35,7 @@ class TunedDeepLearningClassifier(BaseDeepClassifier):
         :param base_model: an implementation of BaseDeepLearner, the model to tune
         :param param_grid: dict, parameter names corresponding to parameters of the base_model, mapped to values to
                             search over
-        :param search_method: string out of ['grid', 'random], how to search over the param_grid
+        :param search_method: string out of ['grid', 'random'], how to search over the param_grid
         :param cv_folds: int, number of cross validation folds to use in evaluation of each parameter set
         :param random_seed: int, seed to any needed random actions
         :param verbose: boolean, whether to output extra information

--- a/sktime_dl/meta/_dltuner.py
+++ b/sktime_dl/meta/_dltuner.py
@@ -2,7 +2,7 @@ __author__ = "James Large"
 
 import numpy as np
 
-from sktime_dl.deeplearning.base.estimators._classifier import BaseDeepClassifier
+from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning import CNNClassifier
 
 from sklearn.model_selection import GridSearchCV


### PR DESCRIPTION
First pass of #29 with minimal effort, simply adding list of callbacks (default []) to networks that have a simple fit pass. 

MCDCNN, MCNN and TWIESN do not have these. The former two are composite models/have bespoke training methods, and the latter is not really a network that trains with fit 

Continuations could include something like a utils.callbacks.py file that defines default/common callbacks for easier use, e.g. model checkpointing etc. However current solution adequately allows user to define arbitrarily complex callbacks 