### PR TITLE
Multivariate and validation data handling

### DIFF
--- a/sktime_dl/deeplearning/base/estimators/_classifier.py
+++ b/sktime_dl/deeplearning/base/estimators/_classifier.py
@@ -77,7 +77,8 @@ class BaseDeepClassifier(BaseClassifier):
         if (label_encoder is None) and (onehot_encoder is None):
             # make the encoders and store in self
             self.label_encoder = LabelEncoder()
-            self.onehot_encoder = OneHotEncoder(sparse=False, categories="auto")
+            self.onehot_encoder = OneHotEncoder(sparse=False,
+                                                categories="auto")
             # categories='auto' to get rid of FutureWarning
 
             y = self.label_encoder.fit_transform(y)

--- a/sktime_dl/deeplearning/base/estimators/_classifier.py
+++ b/sktime_dl/deeplearning/base/estimators/_classifier.py
@@ -26,6 +26,8 @@ class BaseDeepClassifier(BaseClassifier):
         """
         Construct a compiled, un-trained, keras model that is ready for
         training
+
+        Parameters
         ----------
         input_shape : tuple
             The shape of the data fed into the input layer
@@ -43,14 +45,10 @@ class BaseDeepClassifier(BaseClassifier):
         Find probability estimates for each class for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame is passed (sktime format)
-            If a Pandas data frame is passed, a check is performed that it
-            only has one column.
-            If not, an exception is thrown, since this classifier does not
-            yet have
-            multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/deeplearning/base/estimators/_classifier.py
+++ b/sktime_dl/deeplearning/base/estimators/_classifier.py
@@ -75,16 +75,24 @@ class BaseDeepClassifier(BaseClassifier):
             self.model, self.model_save_directory, self.model_name
         )
 
-    def convert_y(self, y):
-        self.label_encoder = LabelEncoder()
-        self.onehot_encoder = OneHotEncoder(sparse=False, categories="auto")
-        # categories='auto' to get rid of FutureWarning
+    def convert_y(self, y, label_encoder=None, onehot_encoder=None):
+        if (label_encoder is None) and (onehot_encoder is None):
+            # make the encoders and store in self
+            self.label_encoder = LabelEncoder()
+            self.onehot_encoder = OneHotEncoder(sparse=False, categories="auto")
+            # categories='auto' to get rid of FutureWarning
 
-        y = self.label_encoder.fit_transform(y)
-        self.classes_ = self.label_encoder.classes_
-        self.nb_classes = len(self.classes_)
+            y = self.label_encoder.fit_transform(y)
+            self.classes_ = self.label_encoder.classes_
+            self.nb_classes = len(self.classes_)
 
-        y = y.reshape(len(y), 1)
-        y = self.onehot_encoder.fit_transform(y)
+            y = y.reshape(len(y), 1)
+            y = self.onehot_encoder.fit_transform(y)
+        else:
+            # encoders given, just transform using those. used for e.g.
+            # validation data, where the train data has already been converted
+            y = label_encoder.fit_transform(y)
+            y = y.reshape(len(y), 1)
+            y = onehot_encoder.fit_transform(y)
 
         return y

--- a/sktime_dl/deeplearning/base/estimators/_regressor.py
+++ b/sktime_dl/deeplearning/base/estimators/_regressor.py
@@ -19,6 +19,7 @@ class BaseDeepRegressor(BaseRegressor, RegressorMixin):
     def build_model(self, input_shape, **kwargs):
         """
         Construct a compiled, un-trained, keras model that is ready for
+        training
 
         Parameters
         ----------
@@ -36,12 +37,10 @@ class BaseDeepRegressor(BaseRegressor, RegressorMixin):
         Find regression estimate for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame of Series objects is passed (sktime
-            format), a check is performed that it only has one column.
-            If not, an exception is thrown, since this regressor does not yet
-            have multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/deeplearning/cnn/_classifier.py
+++ b/sktime_dl/deeplearning/cnn/_classifier.py
@@ -100,15 +100,26 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-            column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/cnn/_classifier.py
+++ b/sktime_dl/deeplearning/cnn/_classifier.py
@@ -2,7 +2,8 @@ __author__ = "James Large"
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.cnn._base import CNNNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 from sklearn.utils import check_random_state
 from tensorflow import keras
 
@@ -96,7 +97,8 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
@@ -119,6 +121,11 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -135,6 +142,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self._is_fitted = True

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -127,7 +127,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -127,9 +127,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -97,15 +97,26 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.cnn._base import CNNNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class CNNRegressor(BaseDeepRegressor, CNNNetwork):
@@ -93,7 +94,8 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y)
         ----------
@@ -113,6 +115,11 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
 
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -129,6 +136,7 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -2,7 +2,8 @@ __author__ = "James Large"
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.encoder._base import EncoderNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 from tensorflow import keras
 from sklearn.utils import check_random_state
 
@@ -89,7 +90,8 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
@@ -112,6 +114,11 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -128,6 +135,7 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -93,15 +93,26 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-             column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.encoder._base import EncoderNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
@@ -92,7 +93,8 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y)
         ----------
@@ -112,6 +114,11 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
 
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -128,6 +135,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -96,15 +96,26 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -126,7 +126,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -126,9 +126,7 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.fcn._base import FCNNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 from sklearn.utils import check_random_state
 
 
@@ -102,7 +103,8 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
@@ -122,6 +124,11 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -140,6 +147,7 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -106,15 +106,26 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-            column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.fcn._base import FCNNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class FCNRegressor(BaseDeepRegressor, FCNNetwork):
@@ -103,7 +104,8 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y)
         ----------
@@ -119,6 +121,11 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         self : object
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
@@ -138,6 +145,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -107,15 +107,26 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -134,9 +134,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -134,7 +134,7 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -127,15 +127,26 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-             column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -2,7 +2,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.inceptiontime._base import InceptionTimeNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 from sklearn.utils import check_random_state
 
 
@@ -123,7 +124,8 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
@@ -142,6 +144,11 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
 
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
@@ -164,6 +171,7 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -152,9 +152,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.inceptiontime._base import InceptionTimeNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
@@ -121,7 +122,8 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y)
         ----------
@@ -137,6 +139,11 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         self : object
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
@@ -159,6 +166,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -152,7 +152,7 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -125,15 +125,26 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/lstm/_regressor.py
+++ b/sktime_dl/deeplearning/lstm/_regressor.py
@@ -94,7 +94,7 @@ class LSTMRegressor(BaseDeepRegressor, LSTMNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         self.input_shape = X.shape[1:]
 

--- a/sktime_dl/deeplearning/lstm/_regressor.py
+++ b/sktime_dl/deeplearning/lstm/_regressor.py
@@ -94,9 +94,7 @@ class LSTMRegressor(BaseDeepRegressor, LSTMNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         self.input_shape = X.shape[1:]
 

--- a/sktime_dl/deeplearning/lstm/_regressor.py
+++ b/sktime_dl/deeplearning/lstm/_regressor.py
@@ -67,15 +67,26 @@ class LSTMRegressor(BaseDeepRegressor, LSTMNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-            objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -1,7 +1,6 @@
 __author__ = "James Large"
 
 import numpy as np
-from sklearn.model_selection import train_test_split
 from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -172,7 +172,7 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
         self.input_shape = X.shape[1:]
 
         X = self.prepare_input(X)
-        if validation_data[0] is not None:
+        if validation_data is not None:
             validation_data = (
                 self.prepare_input(validation_data[0]),
                 validation_data[1]

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -134,15 +134,26 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-             column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object
@@ -190,14 +201,10 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
         Find probability estimates for each class for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame is passed (sktime format)
-            If a Pandas data frame is passed, a check is performed that it
-            only has one column.
-            If not, an exception is thrown, since this classifier does not
-            yet have
-            multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -174,7 +174,10 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
 
         X = self.prepare_input(X)
         if validation_data[0] is not None:
-            validation_data[0] = self.prepare_input(validation_data[0])
+            validation_data = (
+                self.prepare_input(validation_data[0]),
+                validation_data[1]
+            )
 
         self.model = self.build_model(self.input_shape, self.nb_classes)
 

--- a/sktime_dl/deeplearning/mcdcnn/_regressor.py
+++ b/sktime_dl/deeplearning/mcdcnn/_regressor.py
@@ -145,7 +145,7 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance

--- a/sktime_dl/deeplearning/mcdcnn/_regressor.py
+++ b/sktime_dl/deeplearning/mcdcnn/_regressor.py
@@ -146,9 +146,7 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
@@ -156,7 +154,10 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
 
         X = self.prepare_input(X)
         if validation_data[0] is not None:
-            validation_data[0] = self.prepare_input(validation_data[0])
+            validation_data = (
+                self.prepare_input(validation_data[0]),
+                validation_data[1]
+            )
 
         self.model = self.build_model(self.input_shape)
 

--- a/sktime_dl/deeplearning/mcdcnn/_regressor.py
+++ b/sktime_dl/deeplearning/mcdcnn/_regressor.py
@@ -1,6 +1,5 @@
 __author__ = "James Large, Withington"
 
-from sklearn.model_selection import train_test_split
 from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor

--- a/sktime_dl/deeplearning/mcdcnn/_regressor.py
+++ b/sktime_dl/deeplearning/mcdcnn/_regressor.py
@@ -152,7 +152,7 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
         self.input_shape = X.shape[1:]
 
         X = self.prepare_input(X)
-        if validation_data[0] is not None:
+        if validation_data is not None:
             validation_data = (
                 self.prepare_input(validation_data[0]),
                 validation_data[1]

--- a/sktime_dl/deeplearning/mcdcnn/_regressor.py
+++ b/sktime_dl/deeplearning/mcdcnn/_regressor.py
@@ -119,15 +119,26 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/mcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcnn/_classifier.py
@@ -503,11 +503,12 @@ class MCNNClassifier(BaseDeepClassifier):
 
     def fit(self, X, y, input_checks=True, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-            column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
             The class labels.
         input_checks: boolean
@@ -562,14 +563,10 @@ class MCNNClassifier(BaseDeepClassifier):
         Find probability estimates for each class for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame is passed (sktime format)
-            If a Pandas data frame is passed, a check is performed that it
-             only has one column.
-            If not, an exception is thrown, since this classifier does not
-             yet have
-            multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/deeplearning/mlp/_classifier.py
+++ b/sktime_dl/deeplearning/mlp/_classifier.py
@@ -103,21 +103,26 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
+            The training data class labels.
         input_checks : boolean
             whether to check the X and y parameters
-        validation_X : array-like or sparse matrix of shape = [n_val_instances,
-            n_val_columns]
-            The validation samples, predicted at each training epoch. This data
-            is not used for training in any way.
-        validation_y : array-like, shape = [n_val_instances]
-            The validation class labels. This data is not used for training in
-            any way.
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/mlp/_classifier.py
+++ b/sktime_dl/deeplearning/mlp/_classifier.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.mlp._base import MLPNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 from sklearn.utils import check_random_state
 
 
@@ -99,17 +100,24 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
         X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-            column 0 is extracted.
+            The training input samples.
         y : array-like, shape = [n_instances]
             The class labels.
-        input_checks: boolean
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : array-like or sparse matrix of shape = [n_val_instances,
+            n_val_columns]
+            The validation samples, predicted at each training epoch. This data
+            is not used for training in any way.
+        validation_y : array-like, shape = [n_val_instances]
+            The validation class labels. This data is not used for training in
+            any way.
         Returns
         -------
         self : object
@@ -118,6 +126,11 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
 
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance
@@ -137,6 +150,7 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -108,12 +108,29 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y) ---------- X :
-        array-like or sparse matrix of shape = [n_instances, n_columns] The
-        training input samples.  If a Pandas data frame of Series objects is
-        passed, column 0 is extracted. y : array-like, shape = [n_instances]
-        The regression values. input_checks: boolean whether to check the X
-        and y parameters Returns ------- self : object
+        Fit the regressor on the training set (X, y)
+        ----------
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+        y : array-like, shape = [n_instances]
+            The training data class labels.
+        input_checks : boolean
+            whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
+        Returns
+        -------
+        self : object
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
 

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.mlp._base import MLPNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class MLPRegressor(BaseDeepRegressor, MLPNetwork):
@@ -104,7 +105,8 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y) ---------- X :
         array-like or sparse matrix of shape = [n_instances, n_columns] The
@@ -114,6 +116,11 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         and y parameters Returns ------- self : object
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance
@@ -133,6 +140,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -135,7 +135,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -135,9 +135,7 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -118,15 +118,26 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-            column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.resnet._base import ResNetNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 from sklearn.utils import check_random_state
 
 
@@ -114,7 +115,8 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
@@ -134,6 +136,11 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -152,6 +159,7 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -4,7 +4,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.resnet._base import ResNetNetwork
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
@@ -108,7 +109,8 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y)
         ----------
@@ -124,6 +126,11 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         self : object
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance
@@ -143,6 +150,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -112,15 +112,26 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -139,7 +139,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -139,9 +139,7 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         # ignore the number of instances, X.shape[0], just want the shape of
         # each instance

--- a/sktime_dl/deeplearning/rnn/_regressor.py
+++ b/sktime_dl/deeplearning/rnn/_regressor.py
@@ -81,6 +81,31 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
 
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
+        """
+        Fit the regressor on the training set (X, y)
+        ----------
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+        y : array-like, shape = [n_instances]
+            The training data class labels.
+        input_checks : boolean
+            whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
+        Returns
+        -------
+        self : object
+        """
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \

--- a/sktime_dl/deeplearning/rnn/_regressor.py
+++ b/sktime_dl/deeplearning/rnn/_regressor.py
@@ -109,9 +109,7 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
+            check_and_clean_validation_data(validation_X)
 
         self.input_shape = X.shape[1:]
         self.batch_size = int(max(1, min(X.shape[0] / 10, self.batch_size)))

--- a/sktime_dl/deeplearning/rnn/_regressor.py
+++ b/sktime_dl/deeplearning/rnn/_regressor.py
@@ -109,7 +109,7 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
 
         self.input_shape = X.shape[1:]
         self.batch_size = int(max(1, min(X.shape[0] / 10, self.batch_size)))

--- a/sktime_dl/deeplearning/rnn/_regressor.py
+++ b/sktime_dl/deeplearning/rnn/_regressor.py
@@ -12,7 +12,8 @@ from tensorflow.keras.optimizers import RMSprop
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepNetwork
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
-from sktime_dl.utils import check_and_clean_data
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data
 
 
 class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
@@ -78,8 +79,15 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
             self.callbacks.append(reduce_lr)
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         X = check_and_clean_data(X, y, input_checks=input_checks)
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         self.input_shape = X.shape[1:]
         self.batch_size = int(max(1, min(X.shape[0] / 10, self.batch_size)))
 
@@ -95,6 +103,7 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
         self.save_trained_model()
         self._is_fitted = True

--- a/sktime_dl/deeplearning/tests/test_accuracy.py
+++ b/sktime_dl/deeplearning/tests/test_accuracy.py
@@ -27,9 +27,11 @@ def is_not_value_error(err, *args):
     return not issubclass(err[0], ValueError)
 
 
-ACCURACY_DEVIATION_THRESHOLD = (
-    3  # times the std deviation of reported results, if available
-)
+# times the std deviation of reported results, if available
+ACCURACY_DEVIATION_THRESHOLD = 3
+
+# number of times to retry the test in case of catastrophic initialisation
+MAX_RUNS = 5
 
 
 def accuracy_test(network, lower=0.94, upper=1.0):
@@ -49,7 +51,7 @@ def accuracy_test(network, lower=0.94, upper=1.0):
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_cnn_accuracy():
     accuracy_test(
         network=CNNClassifier(),
@@ -58,7 +60,7 @@ def test_cnn_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_encoder_accuracy():
     accuracy_test(
         network=EncoderClassifier(),
@@ -67,7 +69,7 @@ def test_encoder_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_fcn_accuracy():
     accuracy_test(
         network=FCNClassifier(),
@@ -76,7 +78,7 @@ def test_fcn_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_mcdcnn_accuracy():
     accuracy_test(
         network=MCDCNNClassifier(),
@@ -87,7 +89,7 @@ def test_mcdcnn_accuracy():
 @pytest.mark.skipif("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
                     reason="Very slow running, causes Travis to time out.")
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_mcnn_accuracy():
     # Low accuracy is consistent with published results
     # https://github.com/hfawaz/dl-4-tsc/blob/master/README.md
@@ -105,7 +107,7 @@ def test_mcnn_accuracy():
     os.environ["PYTHON_VERSION"] == "3.6",
     reason="Very slow running, causes Travis to time out."
 )
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_mlp_accuracy():
     accuracy_test(
         network=MLPClassifier(),
@@ -114,7 +116,7 @@ def test_mlp_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_resnet_accuracy():
     accuracy_test(
         network=ResNetClassifier(),
@@ -123,7 +125,7 @@ def test_resnet_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_tlenet_accuracy():
     # Accuracy is higher than the 0.490 in the published results
     # https://github.com/hfawaz/dl-4-tsc/blob/master/README.md
@@ -131,7 +133,7 @@ def test_tlenet_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_twiesn_accuracy():
     accuracy_test(
         network=TWIESNClassifier(),
@@ -140,7 +142,7 @@ def test_twiesn_accuracy():
 
 
 @pytest.mark.slow
-@flaky(max_runs=3, rerun_filter=is_not_value_error)
+@flaky(max_runs=MAX_RUNS, rerun_filter=is_not_value_error)
 def test_inception_accuracy():
     accuracy_test(network=InceptionTimeClassifier(), lower=0.96)
 

--- a/sktime_dl/deeplearning/tests/test_classifiers.py
+++ b/sktime_dl/deeplearning/tests/test_classifiers.py
@@ -101,13 +101,13 @@ def test_basic_multivariate(network=CNNClassifier(nb_epochs=SMALL_NB_EPOCHS)):
 
 
 def test_all_networks():
-    for network in construct_all_classifiers(SMALL_NB_EPOCHS):
-        print("\n\t\t" + network.__class__.__name__ + " testing started")
+    for name, network in construct_all_classifiers(SMALL_NB_EPOCHS).items():
+        print("\n\t\t" + name + " testing started")
         # test_basic_univariate(network)
         test_basic_multivariate(network)
         # test_pipeline(network)
         test_highLevelsktime(network)
-        print("\t\t" + network.__class__.__name__ + " testing finished")
+        print("\t\t" + name + " testing finished")
 
 
 if __name__ == "__main__":

--- a/sktime_dl/deeplearning/tests/test_is_fitted.py
+++ b/sktime_dl/deeplearning/tests/test_is_fitted.py
@@ -29,9 +29,10 @@ def test_is_fitted(network=CNNClassifier()):
 
 
 def test_all_networks():
-    networks = construct_all_classifiers(
-        SMALL_NB_EPOCHS
-    ) + construct_all_regressors(SMALL_NB_EPOCHS)
+    networks = {
+        **construct_all_classifiers(SMALL_NB_EPOCHS),
+        **construct_all_regressors(SMALL_NB_EPOCHS),
+    }
 
     for name, network in networks.items():
         print("\n\t\t" + name + " is_fitted testing started")

--- a/sktime_dl/deeplearning/tests/test_is_fitted.py
+++ b/sktime_dl/deeplearning/tests/test_is_fitted.py
@@ -33,16 +33,10 @@ def test_all_networks():
         SMALL_NB_EPOCHS
     ) + construct_all_regressors(SMALL_NB_EPOCHS)
 
-    for network in networks:
-        print(
-            "\n\t\t"
-            + network.__class__.__name__
-            + " is_fitted testing started"
-        )
+    for name, network in networks.items():
+        print("\n\t\t" + name + " is_fitted testing started")
         test_is_fitted(network)
-        print(
-            "\t\t" + network.__class__.__name__ + " is_fitted testing finished"
-        )
+        print("\t\t" + name + " is_fitted testing finished")
 
 
 if __name__ == "__main__":

--- a/sktime_dl/deeplearning/tests/test_regressors.py
+++ b/sktime_dl/deeplearning/tests/test_regressors.py
@@ -70,10 +70,10 @@ def test_regressor(estimator=MLPRegressor(nb_epochs=SMALL_NB_EPOCHS)):
 
 
 def test_all_regressors():
-    for network in construct_all_regressors(SMALL_NB_EPOCHS):
-        print("\n\t\t" + network.__class__.__name__ + " testing started")
+    for name, network in construct_all_regressors(SMALL_NB_EPOCHS).items():
+        print("\n\t\t" + name + " testing started")
         test_regressor(network)
-        print("\t\t" + network.__class__.__name__ + " testing finished")
+        print("\t\t" + name + " testing finished")
 
 # def test_all_forecasters():
 #     window_length = 8

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -1,21 +1,29 @@
 import numpy as np
 import pytest
-from sktime.exceptions import NotFittedError
 from sktime.datasets import load_italy_power_demand
 from sktime.regression.base import BaseRegressor
 
-from sktime_dl.deeplearning import CNNClassifier
+from sktime_dl.deeplearning import MLPClassifier
 from sktime_dl.utils.model_lists import SMALL_NB_EPOCHS
 from sktime_dl.utils.model_lists import construct_all_classifiers
 from sktime_dl.utils.model_lists import construct_all_regressors
 
+from sktime_dl.deeplearning import InceptionTimeClassifier
+from sktime_dl.deeplearning import ResNetClassifier
 
-def test_is_fitted(network=CNNClassifier()):
+
+def test_validation(network=MLPClassifier()):
     """
     testing that the networks correctly recognise when they are not fitted
     """
 
     X_train, y_train = load_italy_power_demand(split="train", return_X_y=True)
+
+    X_test = X_train[6:10]
+    y_test = y_train[6:10]
+
+    X_train = X_train[:5]
+    y_train = y_train[:5]
 
     if isinstance(network, BaseRegressor):
         # Create some regression values, taken from test_regressor
@@ -23,15 +31,22 @@ def test_is_fitted(network=CNNClassifier()):
         for i in range(len(X_train)):
             y_train[i] = X_train.iloc[i].iloc[0].iloc[0]
 
-    # try to predict without fitting: SHOULD fail
-    with pytest.raises(NotFittedError):
-        network.predict(X_train[:10])
+    network.fit(X_train, y_train, validation_X=X_test, validation_y=y_test)
+    hist = network.history.history
+
+    assert ('val_loss' in hist) and ('val_accuracy' in hist)
 
 
 def test_all_networks():
-    networks = construct_all_classifiers(
-        SMALL_NB_EPOCHS
-    ) + construct_all_regressors(SMALL_NB_EPOCHS)
+    # expand to all once implemented in all
+    # networks = construct_all_classifiers(
+    #     SMALL_NB_EPOCHS
+    # ) + construct_all_regressors(SMALL_NB_EPOCHS)
+    networks = [
+        MLPClassifier(nb_epochs=SMALL_NB_EPOCHS),
+        ResNetClassifier(nb_epochs=SMALL_NB_EPOCHS),
+        InceptionTimeClassifier(nb_epochs=SMALL_NB_EPOCHS),
+    ]
 
     for network in networks:
         print(
@@ -39,7 +54,7 @@ def test_all_networks():
             + network.__class__.__name__
             + " is_fitted testing started"
         )
-        test_is_fitted(network)
+        test_validation(network)
         print(
             "\t\t" + network.__class__.__name__ + " is_fitted testing finished"
         )

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -8,7 +8,6 @@ from sktime_dl.utils.model_lists import construct_all_classifiers
 from sktime_dl.utils.model_lists import construct_all_regressors
 
 
-
 def test_validation(network=MLPClassifier()):
     """
     testing that the networks correctly recognise when they are not fitted
@@ -37,7 +36,6 @@ def test_validation(network=MLPClassifier()):
 
 
 def test_all_networks():
-    # expand to all once implemented in all. currently 'difficult' networks, mcnn, twiesn,
     networks = {
         **construct_all_classifiers(SMALL_NB_EPOCHS),
         **construct_all_regressors(SMALL_NB_EPOCHS),

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -15,17 +15,21 @@ def test_validation(network=MLPClassifier()):
 
     X_train, y_train = load_italy_power_demand(split="train", return_X_y=True)
 
-    X_test = X_train[10:20]
-    y_test = y_train[10:20]
+    X_test = X_train[5:10]
+    y_test = y_train[5:10]
 
-    X_train = X_train[:10]
-    y_train = y_train[:10]
+    X_train = X_train[:5]
+    y_train = y_train[:5]
 
     if isinstance(network, BaseRegressor):
         # Create some regression values, taken from test_regressor
         y_train = np.zeros(len(y_train))
         for i in range(len(X_train)):
             y_train[i] = X_train.iloc[i].iloc[0].iloc[0]
+
+        y_test = np.zeros(len(y_test))
+        for i in range(len(X_test)):
+            y_test[i] = X_test.iloc[i].iloc[0].iloc[0]
 
     network.fit(X_train, y_train, validation_X=X_test, validation_y=y_test)
     hist = network.history.history
@@ -37,13 +41,13 @@ def test_validation(network=MLPClassifier()):
 
 def test_all_networks():
     networks = {
-        **construct_all_classifiers(SMALL_NB_EPOCHS),
+        # **construct_all_classifiers(SMALL_NB_EPOCHS),
         **construct_all_regressors(SMALL_NB_EPOCHS),
     }
 
     # these networks do not support validation data as yet
-    networks.pop('MCNNClassifier_quick')
-    networks.pop('TWIESNClassifier_quick')
+    # networks.pop('MCNNClassifier_quick')
+    # networks.pop('TWIESNClassifier_quick')
 
     # networks = [
     #     MLPClassifier(nb_epochs=SMALL_NB_EPOCHS),

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -10,7 +10,7 @@ from sktime_dl.utils.model_lists import construct_all_regressors
 
 def test_validation(network=MLPClassifier()):
     """
-    testing that the networks correctly recognise when they are not fitted
+    testing that the networks log validation predictions in the history object
     """
 
     X_train, y_train = load_italy_power_demand(split="train", return_X_y=True)

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from sktime.datasets import load_italy_power_demand
 from sktime.regression.base import BaseRegressor
 
@@ -8,8 +7,6 @@ from sktime_dl.utils.model_lists import SMALL_NB_EPOCHS
 from sktime_dl.utils.model_lists import construct_all_classifiers
 from sktime_dl.utils.model_lists import construct_all_regressors
 
-from sktime_dl.deeplearning import InceptionTimeClassifier
-from sktime_dl.deeplearning import ResNetClassifier
 
 
 def test_validation(network=MLPClassifier()):
@@ -34,30 +31,32 @@ def test_validation(network=MLPClassifier()):
     network.fit(X_train, y_train, validation_X=X_test, validation_y=y_test)
     hist = network.history.history
 
-    assert ('val_loss' in hist) and ('val_accuracy' in hist)
+    assert ('val_loss' in hist)
+    assert (isinstance(hist['val_loss'][0],
+                       (float, np.single, np.double, np.float32, np.float64)))
 
 
 def test_all_networks():
-    # expand to all once implemented in all
-    # networks = construct_all_classifiers(
-    #     SMALL_NB_EPOCHS
-    # ) + construct_all_regressors(SMALL_NB_EPOCHS)
-    networks = [
-        MLPClassifier(nb_epochs=SMALL_NB_EPOCHS),
-        ResNetClassifier(nb_epochs=SMALL_NB_EPOCHS),
-        InceptionTimeClassifier(nb_epochs=SMALL_NB_EPOCHS),
-    ]
+    # expand to all once implemented in all. currently 'difficult' networks, mcnn, twiesn,
+    networks = {
+        **construct_all_classifiers(SMALL_NB_EPOCHS),
+        **construct_all_regressors(SMALL_NB_EPOCHS),
+    }
 
-    for network in networks:
-        print(
-            "\n\t\t"
-            + network.__class__.__name__
-            + " is_fitted testing started"
-        )
+    # these networks do not support validation data as yet
+    networks.pop('MCNNClassifier_quick')
+    networks.pop('TWIESNClassifier_quick')
+
+    # networks = [
+    #     MLPClassifier(nb_epochs=SMALL_NB_EPOCHS),
+    #     ResNetClassifier(nb_epochs=SMALL_NB_EPOCHS),
+    #     InceptionTimeClassifier(nb_epochs=SMALL_NB_EPOCHS),
+    # ]
+
+    for name, network in networks.items():
+        print("\n\t\t" + name + " validation testing started")
         test_validation(network)
-        print(
-            "\t\t" + network.__class__.__name__ + " is_fitted testing finished"
-        )
+        print("\t\t" + name + " validation testing finished")
 
 
 if __name__ == "__main__":

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -15,11 +15,11 @@ def test_validation(network=MLPClassifier()):
 
     X_train, y_train = load_italy_power_demand(split="train", return_X_y=True)
 
-    X_test = X_train[5:10]
-    y_test = y_train[5:10]
+    X_test = X_train[10:20]
+    y_test = y_train[10:20]
 
-    X_train = X_train[:5]
-    y_train = y_train[:5]
+    X_train = X_train[:10]
+    y_train = y_train[:10]
 
     if isinstance(network, BaseRegressor):
         # Create some regression values, taken from test_regressor

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -15,11 +15,11 @@ def test_validation(network=MLPClassifier()):
 
     X_train, y_train = load_italy_power_demand(split="train", return_X_y=True)
 
-    X_test = X_train[6:10]
-    y_test = y_train[6:10]
+    X_test = X_train[10:15]
+    y_test = y_train[10:15]
 
-    X_train = X_train[:5]
-    y_train = y_train[:5]
+    X_train = X_train[:10]
+    y_train = y_train[:10]
 
     if isinstance(network, BaseRegressor):
         # Create some regression values, taken from test_regressor

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -15,8 +15,8 @@ def test_validation(network=MLPClassifier()):
 
     X_train, y_train = load_italy_power_demand(split="train", return_X_y=True)
 
-    X_test = X_train[10:15]
-    y_test = y_train[10:15]
+    X_test = X_train[10:20]
+    y_test = y_train[10:20]
 
     X_train = X_train[:10]
     y_train = y_train[:10]

--- a/sktime_dl/deeplearning/tests/test_validation.py
+++ b/sktime_dl/deeplearning/tests/test_validation.py
@@ -41,13 +41,13 @@ def test_validation(network=MLPClassifier()):
 
 def test_all_networks():
     networks = {
-        # **construct_all_classifiers(SMALL_NB_EPOCHS),
+        **construct_all_classifiers(SMALL_NB_EPOCHS),
         **construct_all_regressors(SMALL_NB_EPOCHS),
     }
 
     # these networks do not support validation data as yet
-    # networks.pop('MCNNClassifier_quick')
-    # networks.pop('TWIESNClassifier_quick')
+    networks.pop('MCNNClassifier_quick')
+    networks.pop('TWIESNClassifier_quick')
 
     # networks = [
     #     MLPClassifier(nb_epochs=SMALL_NB_EPOCHS),

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -4,7 +4,8 @@ import numpy as np
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepClassifier
 from sktime_dl.deeplearning.tlenet._base import TLENETNetwork
-from sktime_dl.utils import check_and_clean_data, check_is_fitted
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data, check_is_fitted
 from tensorflow import keras
 from sklearn.utils import check_random_state
 
@@ -98,7 +99,8 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the classifier on the training set (X, y)
         ----------
@@ -121,6 +123,11 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -142,6 +149,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -134,26 +134,28 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
-        validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
 
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
-
         self.nb_classes = y_onehot.shape[1]
 
         self.adjust_parameters(X)
-        X, y_onehot, tot_increase_num = self.pre_processing(X, y_onehot)
+        X, y_onehot, _ = self.pre_processing(X, y_onehot)
 
-        input_shape = X.shape[
-                      1:
-                      ]  # pylint: disable=E1136  # pylint/issues/3139
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+        val_X, val_y, _ = self.pre_processing(validation_data[0],
+                                              validation_data[1])
+        validation_data = (val_X, val_y)
+
+        input_shape = X.shape[1:]
         self.model = self.build_model(input_shape, self.nb_classes)
 
-        self.hist = self.model.fit(
+        self.history = self.model.fit(
             X,
             y_onehot,
             batch_size=self.batch_size,
@@ -194,8 +196,10 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         test_num_batch = int(X.shape[0] / tot_increase_num)
 
         y_predicted = [np.average(preds[i * tot_increase_num:(
-            (i + 1) * tot_increase_num) - 1], axis=0)
-            for i in range(test_num_batch)]
+                                                                     (
+                                                                                 i + 1) * tot_increase_num) - 1],
+                                  axis=0)
+                       for i in range(test_num_batch)]
 
         y_pred = np.array(y_predicted)
 

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -193,11 +193,12 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         test_num_batch = int(X.shape[0] / tot_increase_num)
 
-        y_predicted = [np.average(preds[i * tot_increase_num:(
-                                                                     (
-                                                                             i + 1) * tot_increase_num) - 1],
-                                  axis=0)
-                       for i in range(test_num_batch)]
+        y_predicted = [
+            np.average(
+                preds[i * tot_increase_num:((i + 1) * tot_increase_num) - 1],
+                axis=0)
+            for i in range(test_num_batch)
+        ]
 
         y_pred = np.array(y_predicted)
 

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -148,7 +148,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
                                             self.onehot_encoder)
         if validation_data is not None:
             vX, vy, _ = self.pre_processing(validation_data[0],
-                                                  validation_data[1])
+                                            validation_data[1])
             validation_data = (vX, vy)
 
         input_shape = X.shape[1:]

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -102,15 +102,26 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-             column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object
@@ -162,14 +173,10 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         Find probability estimates for each class for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame is passed (sktime format)
-            If a Pandas data frame is passed, a check is performed that it
-             only has one column.
-            If not, an exception is thrown, since this classifier does not
-             yet have
-            multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -146,9 +146,10 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
             check_and_clean_validation_data(validation_X, validation_y,
                                             self.label_encoder,
                                             self.onehot_encoder)
-        val_X, val_y, _ = self.pre_processing(validation_data[0],
-                                              validation_data[1])
-        validation_data = (val_X, val_y)
+        if validation_data is not None:
+            vX, vy, _ = self.pre_processing(validation_data[0],
+                                                  validation_data[1])
+            validation_data = (vX, vy)
 
         input_shape = X.shape[1:]
         self.model = self.build_model(input_shape, self.nb_classes)

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -134,7 +134,6 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         X = check_and_clean_data(X, y, input_checks=input_checks)
         y_onehot = self.convert_y(y)
 
-
         # ignore the number of instances, X.shape[0],
         # just want the shape of each instance
         self.input_shape = X.shape[1:]
@@ -142,7 +141,6 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         self.adjust_parameters(X)
         X, y_onehot, _ = self.pre_processing(X, y_onehot)
-
 
         validation_data = \
             check_and_clean_validation_data(validation_X, validation_y,
@@ -197,7 +195,7 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
 
         y_predicted = [np.average(preds[i * tot_increase_num:(
                                                                      (
-                                                                                 i + 1) * tot_increase_num) - 1],
+                                                                             i + 1) * tot_increase_num) - 1],
                                   axis=0)
                        for i in range(test_num_batch)]
 

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -5,8 +5,8 @@ from tensorflow import keras
 
 from sktime_dl.deeplearning.base.estimators import BaseDeepRegressor
 from sktime_dl.deeplearning.tlenet._base import TLENETNetwork
-from sktime_dl.utils import check_and_clean_data
-from sktime_dl.utils import check_is_fitted
+from sktime_dl.utils import check_and_clean_data, \
+    check_and_clean_validation_data, check_is_fitted
 
 
 class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
@@ -105,7 +105,8 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, input_checks=True, validation_X=None,
+            validation_y=None, **kwargs):
         """
         Build the regressor on the training set (X, y)
         ----------
@@ -122,6 +123,11 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
+        validation_data = \
+            check_and_clean_validation_data(validation_X, validation_y,
+                                            self.label_encoder,
+                                            self.onehot_encoder)
+
         self.adjust_parameters(X)
         X, y, __ = self.pre_processing(X, y)
 
@@ -137,6 +143,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
             epochs=self.nb_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks,
+            validation_data=validation_data,
         )
 
         self.save_trained_model()

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -134,20 +134,20 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         """
         X = check_and_clean_data(X, y, input_checks=input_checks)
 
-        validation_data = \
-            check_and_clean_validation_data(validation_X, validation_y,
-                                            self.label_encoder,
-                                            self.onehot_encoder)
-
         self.adjust_parameters(X)
         X, y, __ = self.pre_processing(X, y)
 
-        input_shape = X.shape[
-                      1:
-                      ]  # pylint: disable=E1136  # pylint/issues/3139
+
+        validation_data = \
+            check_and_clean_validation_data(validation_X)
+        val_X, val_y, _ = self.pre_processing(validation_data[0],
+                                              validation_data[1])
+        validation_data = (val_X, val_y)
+
+        input_shape = X.shape[1:]
         self.model = self.build_model(input_shape)
 
-        self.hist = self.model.fit(
+        self.history = self.model.fit(
             X,
             y,
             batch_size=self.batch_size,

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -138,7 +138,7 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         X, y, __ = self.pre_processing(X, y)
 
         validation_data = \
-            check_and_clean_validation_data(validation_X)
+            check_and_clean_validation_data(validation_X, validation_y)
         if validation_data is not None:
             vX, vy, _ = self.pre_processing(validation_data[0],
                                             validation_data[1])

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -139,9 +139,10 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
 
         validation_data = \
             check_and_clean_validation_data(validation_X)
-        val_X, val_y, _ = self.pre_processing(validation_data[0],
-                                              validation_data[1])
-        validation_data = (val_X, val_y)
+        if validation_data is not None:
+            vX, vy, _ = self.pre_processing(validation_data[0],
+                                            validation_data[1])
+            validation_data = (vX, vy)
 
         input_shape = X.shape[1:]
         self.model = self.build_model(input_shape)

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -137,7 +137,6 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         self.adjust_parameters(X)
         X, y, __ = self.pre_processing(X, y)
 
-
         validation_data = \
             check_and_clean_validation_data(validation_X)
         val_X, val_y, _ = self.pre_processing(validation_data[0],

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -108,15 +108,26 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
     def fit(self, X, y, input_checks=True, validation_X=None,
             validation_y=None, **kwargs):
         """
-        Build the regressor on the training set (X, y)
+        Fit the regressor on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame of Series
-             objects is passed, column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The regression values.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object
@@ -156,12 +167,10 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         Find regression estimate for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame of Series objects is passed (sktime format),
-            a check is performed that it only has one column.
-            If not, an exception is thrown, since this regressor does not yet
-             have multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/deeplearning/twiesn/_classifier.py
+++ b/sktime_dl/deeplearning/twiesn/_classifier.py
@@ -136,16 +136,6 @@ class TWIESNClassifier(BaseDeepClassifier):
             The training data class labels.
         input_checks : boolean
             whether to check the X and y parameters
-        validation_X : a nested pd.Dataframe, or array-like of shape =
-        (n_instances, series_length, n_dimensions)
-            The validation samples. If a 2D array-like is passed,
-            n_dimensions is assumed to be 1.
-            Unless strictly defined by the user via callbacks (such as
-            EarlyStopping), the presence or state of the validation
-            data does not alter training in any way. Predictions at each epoch
-            are stored in the model's fit history.
-        validation_y : array-like, shape = [n_instances]
-            The validation class labels.
         Returns
         -------
         self : object

--- a/sktime_dl/deeplearning/twiesn/_classifier.py
+++ b/sktime_dl/deeplearning/twiesn/_classifier.py
@@ -126,15 +126,26 @@ class TWIESNClassifier(BaseDeepClassifier):
 
     def fit(self, X, y, input_checks=True, **kwargs):
         """
-        Build the classifier on the training set (X, y)
+        Fit the classifier on the training set (X, y)
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.  If a Pandas data frame is passed,
-             column 0 is extracted.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
-            The class labels.
-        input_checks: boolean
+            The training data class labels.
+        input_checks : boolean
             whether to check the X and y parameters
+        validation_X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The validation samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
+            Unless strictly defined by the user via callbacks (such as
+            EarlyStopping), the presence or state of the validation
+            data does not alter training in any way. Predictions at each epoch
+            are stored in the model's fit history.
+        validation_y : array-like, shape = [n_instances]
+            The validation class labels.
         Returns
         -------
         self : object
@@ -216,14 +227,10 @@ class TWIESNClassifier(BaseDeepClassifier):
         Find probability estimates for each class for all cases in X.
         Parameters
         ----------
-        X : array-like or sparse matrix of shape = [n_instances, n_columns]
-            The training input samples.
-            If a Pandas data frame is passed (sktime format)
-            If a Pandas data frame is passed, a check is performed that it
-             only has one column.
-            If not, an exception is thrown, since this classifier does not
-             yet have
-            multivariate capability.
+        X : a nested pd.Dataframe, or array-like of shape =
+        (n_instances, series_length, n_dimensions)
+            The training input samples. If a 2D array-like is passed,
+            n_dimensions is assumed to be 1.
         input_checks: boolean
             whether to check the X parameter
         Returns

--- a/sktime_dl/experimental/reproductions.py
+++ b/sktime_dl/experimental/reproductions.py
@@ -16,7 +16,7 @@ To run a dl experiment:
 
 import sys
 
-if len(sys.argv) > 1:
+if len(sys.argv) > 6:
     setseed = bool(sys.argv[6])
     if setseed:
         # rngseed = int(sys.argv[5])

--- a/sktime_dl/utils/__init__.py
+++ b/sktime_dl/utils/__init__.py
@@ -1,9 +1,11 @@
 __all__ = [
     "check_and_clean_data",
+    "check_and_clean_validation_data",
     "check_is_fitted",
     "save_trained_model"
 ]
 
 from sktime_dl.utils._data import check_and_clean_data
+from sktime_dl.utils._data import check_and_clean_validation_data
 from sktime_dl.utils._models import check_is_fitted
 from sktime_dl.utils._models import save_trained_model

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -41,27 +41,24 @@ def check_and_clean_data(X, y=None, input_checks=True):
 
 def check_and_clean_validation_data(validation_X, validation_y, label_encoder,
                                     onehot_encoder, input_checks=True):
-    x = validation_X is not None
-    y = validation_y is not None
-
-    if x and y:  # both present
+    if validation_X is not None:
         validation_X = check_and_clean_data(validation_X, validation_y,
                                             input_checks=input_checks)
+    else:
+        raise ValueError(
+            'No validation data given to check')
 
+    validation_data = (validation_X, None)
+
+    if validation_y is not None:
         validation_y_onehot = label_encoder.transform(validation_y)
-        validation_y_onehot = validation_y_onehot.reshape(len(validation_y_onehot), 1)
+        validation_y_onehot = validation_y_onehot.reshape(
+            len(validation_y_onehot), 1)
         validation_y_onehot = onehot_encoder.fit_transform(
             validation_y_onehot)
 
         validation_data = (validation_X, validation_y_onehot)
-    elif not x and not y:  # both missing
-        validation_data = None
-    elif x and not y:  # y missing
-        raise ValueError(
-            'Given X data for validation, but y labels are missing')
-    else:  # x missing
-        raise ValueError(
-            'Given y labels for validation, but x data are missing')
+    # validation_y may genuinely be None for some tasks
 
     return validation_data
 

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -48,7 +48,7 @@ def check_and_clean_data(X, y=None, input_checks=True):
     return X
 
 
-def check_and_clean_validation_data(validation_X, validation_y=None,
+def check_and_clean_validation_data(validation_X, validation_y,
                                     label_encoder=None,
                                     onehot_encoder=None, input_checks=True):
     '''
@@ -64,7 +64,7 @@ def check_and_clean_validation_data(validation_X, validation_y=None,
     :param onehot_encoder: if validation_y has been given,
             the encoder that has already been fit to the train data
     :param input_checks: whether to perform the basic input structure checks
-    :return: ( validation_X, validation_y ), ready for use
+    :return: ( validation_X, validation_y ), or None if no data given
     '''
     if validation_X is not None:
         validation_X = check_and_clean_data(validation_X, validation_y,
@@ -72,19 +72,14 @@ def check_and_clean_validation_data(validation_X, validation_y=None,
     else:
         return None
 
-    validation_data = (validation_X, None)
+    if label_encoder is not None and onehot_encoder is not None:
+        validation_y = label_encoder.transform(validation_y)
+        validation_y = validation_y.reshape(
+            len(validation_y), 1)
+        validation_y = onehot_encoder.fit_transform(
+            validation_y)
 
-    if validation_y is not None:
-        validation_y_onehot = label_encoder.transform(validation_y)
-        validation_y_onehot = validation_y_onehot.reshape(
-            len(validation_y_onehot), 1)
-        validation_y_onehot = onehot_encoder.fit_transform(
-            validation_y_onehot)
-
-        validation_data = (validation_X, validation_y_onehot)
-    # validation_y may genuinely be None for some tasks
-
-    return validation_data
+    return (validation_X, validation_y)
 
 
 def _is_nested_dataframe(X):

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -70,7 +70,7 @@ def check_and_clean_validation_data(validation_X, validation_y=None,
         validation_X = check_and_clean_data(validation_X, validation_y,
                                             input_checks=input_checks)
     else:
-        return (None, None)
+        return None
 
     validation_data = (validation_X, None)
 

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -2,9 +2,8 @@
 
 __author__ = "James Large"
 
-import numpy as np
 import pandas as pd
-from sktime.utils.data_container import tabularise
+from sktime.utils.data_container import tabularise, nested_to_3d_numpy
 from sktime.utils.validation.series_as_features import check_X, check_X_y
 
 
@@ -53,16 +52,7 @@ def _univariate_df_to_array(X):
 
 
 def _multivariate_nested_df_to_array(X):
-    # tabularise at time of writing will not keep multivariate dimensions
-    # separate, e.g. [n][m][d] becomes [n][m*d]
-    # todo investigate incorporating the reshaping into the data extraction
-    #  instead of this 2-stage process
-    X = np.array(
-        [
-            [X.iloc[r, c].values for c in range(len(X.columns))]
-            for r in range(len(X))
-        ]
-    )
-    return X.reshape(
-        X.shape[0], X.shape[2], X.shape[1]
-    )  # go from [n][d][m] to [n][m][d]
+    X = nested_to_3d_numpy(X)
+
+    # go from [n][d][m] to [n][m][d]
+    return X.transpose(0, 2, 1)

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -39,6 +39,33 @@ def check_and_clean_data(X, y=None, input_checks=True):
     return X
 
 
+def check_and_clean_validation_data(validation_X, validation_y, label_encoder,
+                                    onehot_encoder, input_checks=True):
+    x = validation_X is not None
+    y = validation_y is not None
+
+    if x and y:  # both present
+        validation_X = check_and_clean_data(validation_X, validation_y,
+                                            input_checks=input_checks)
+
+        validation_y_onehot = label_encoder.transform(validation_y)
+        validation_y_onehot = validation_y_onehot.reshape(len(validation_y_onehot), 1)
+        validation_y_onehot = onehot_encoder.fit_transform(
+            validation_y_onehot)
+
+        validation_data = (validation_X, validation_y_onehot)
+    elif not x and not y:  # both missing
+        validation_data = None
+    elif x and not y:  # y missing
+        raise ValueError(
+            'Given X data for validation, but y labels are missing')
+    else:  # x missing
+        raise ValueError(
+            'Given y labels for validation, but x data are missing')
+
+    return validation_data
+
+
 def _is_nested_dataframe(X):
     return isinstance(X.iloc[0, 0], pd.Series)
 

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -48,7 +48,8 @@ def check_and_clean_data(X, y=None, input_checks=True):
     return X
 
 
-def check_and_clean_validation_data(validation_X, validation_y=None, label_encoder=None,
+def check_and_clean_validation_data(validation_X, validation_y=None,
+                                    label_encoder=None,
                                     onehot_encoder=None, input_checks=True):
     '''
     Performs basic sktime data checks and prepares the validation data for

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -70,8 +70,7 @@ def check_and_clean_validation_data(validation_X, validation_y=None,
         validation_X = check_and_clean_data(validation_X, validation_y,
                                             input_checks=input_checks)
     else:
-        raise ValueError(
-            'No validation data given to check')
+        return (None, None)
 
     validation_data = (validation_X, None)
 

--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -8,6 +8,15 @@ from sktime.utils.validation.series_as_features import check_X, check_X_y
 
 
 def check_and_clean_data(X, y=None, input_checks=True):
+    '''
+    Performs basic sktime data checks and prepares the train data for input to
+    Keras models.
+
+    :param X: the train data
+    :param y: teh train labels
+    :param input_checks: whether to perform the basic sktime checks
+    :return: X
+    '''
     if input_checks:
         if y is None:
             check_X(X)
@@ -39,8 +48,23 @@ def check_and_clean_data(X, y=None, input_checks=True):
     return X
 
 
-def check_and_clean_validation_data(validation_X, validation_y, label_encoder,
-                                    onehot_encoder, input_checks=True):
+def check_and_clean_validation_data(validation_X, validation_y=None, label_encoder=None,
+                                    onehot_encoder=None, input_checks=True):
+    '''
+    Performs basic sktime data checks and prepares the validation data for
+    input to Keras models. Also provides functionality to encode the y labels
+    using label encoders that should have already been fit to the train data.
+
+    :param validation_X: required, validation data
+    :param validation_y: optional, y labels for categorical conversion if
+            needed
+    :param label_encoder: if validation_y has been given,
+            the encoder that has already been fit to the train data
+    :param onehot_encoder: if validation_y has been given,
+            the encoder that has already been fit to the train data
+    :param input_checks: whether to perform the basic input structure checks
+    :return: ( validation_X, validation_y ), ready for use
+    '''
     if validation_X is not None:
         validation_X = check_and_clean_data(validation_X, validation_y,
                                             input_checks=input_checks)

--- a/sktime_dl/utils/model_lists.py
+++ b/sktime_dl/utils/model_lists.py
@@ -28,36 +28,37 @@ def construct_all_classifiers(nb_epochs=None):
 
     :param nb_epochs: int, if not None, value shall be set for all networks
     that accept it
-    :return: list of sktime_dl BaseDeepClassifier imeplementations
+    :return: map of strings to sktime_dl BaseDeepRegressor implementations
     """
     if nb_epochs is not None:
         # potentially quicker versions for tests
-        return [
-            CNNClassifier(nb_epochs=nb_epochs),
-            EncoderClassifier(nb_epochs=nb_epochs),
-            FCNClassifier(nb_epochs=nb_epochs),
-            MCDCNNClassifier(nb_epochs=nb_epochs),
-            MCNNClassifier(nb_epochs=nb_epochs),
-            MLPClassifier(nb_epochs=nb_epochs),
-            ResNetClassifier(nb_epochs=nb_epochs),
-            TLENETClassifier(nb_epochs=nb_epochs),
-            TWIESNClassifier(),
-            InceptionTimeClassifier(nb_epochs=nb_epochs),
-        ]
+        return {
+            'CNNClassifier_quick': CNNClassifier(nb_epochs=nb_epochs),
+            'EncoderClassifier_quick': EncoderClassifier(nb_epochs=nb_epochs),
+            'FCNClassifier_quick': FCNClassifier(nb_epochs=nb_epochs),
+            'MCDCNNClassifier_quick': MCDCNNClassifier(nb_epochs=nb_epochs),
+            'MCNNClassifier_quick': MCNNClassifier(nb_epochs=nb_epochs),
+            'MLPClassifier_quick': MLPClassifier(nb_epochs=nb_epochs),
+            'ResNetClassifier_quick': ResNetClassifier(nb_epochs=nb_epochs),
+            'TLENETClassifier_quick': TLENETClassifier(nb_epochs=nb_epochs),
+            'TWIESNClassifier_quick': TWIESNClassifier(),
+            'InceptionTimeClassifier_quick': InceptionTimeClassifier(
+                nb_epochs=nb_epochs),
+        }
     else:
         # the 'literature-conforming' versions
-        return [
-            CNNClassifier(),
-            EncoderClassifier(),
-            FCNClassifier(),
-            MCDCNNClassifier(),
-            MCNNClassifier(),
-            MLPClassifier(),
-            ResNetClassifier(),
-            TLENETClassifier(),
-            TWIESNClassifier(),
-            InceptionTimeClassifier(),
-        ]
+        return {
+            'CNNClassifier': CNNClassifier(),
+            'EncoderClassifier': EncoderClassifier(),
+            'FCNClassifier': FCNClassifier(),
+            'MCDCNNClassifier': MCDCNNClassifier(),
+            'MCNNClassifier': MCNNClassifier(),
+            'MLPClassifier': MLPClassifier(),
+            'ResNetClassifier': ResNetClassifier(),
+            'TLENETClassifier': TLENETClassifier(),
+            'TWIESNClassifier': TWIESNClassifier(),
+            'InceptionTimeClassifier': InceptionTimeClassifier(),
+        }
 
 
 def construct_all_regressors(nb_epochs=None):
@@ -66,33 +67,38 @@ def construct_all_regressors(nb_epochs=None):
 
     :param nb_epochs: int, if not None, value shall be set for all networks
     that accept it
-    :return: list of sktime_dl BaseDeepRegressor imeplementations
+    :return: map of strings to sktime_dl BaseDeepRegressor implementations
     """
     if nb_epochs is not None:
         # potentially quicker versions for tests
-        return [
-            CNNRegressor(nb_epochs=nb_epochs, kernel_size=3, avg_pool_size=1),
-            EncoderRegressor(nb_epochs=nb_epochs),
-            FCNRegressor(nb_epochs=nb_epochs),
-            LSTMRegressor(nb_epochs=nb_epochs),
-            MCDCNNRegressor(nb_epochs=nb_epochs, dense_units=1),
-            MLPRegressor(nb_epochs=nb_epochs),
-            ResNetRegressor(nb_epochs=nb_epochs),
-            TLENETRegressor(nb_epochs=nb_epochs),
-            InceptionTimeRegressor(nb_epochs=nb_epochs),
-            SimpleRNNRegressor(nb_epochs=nb_epochs),
-        ]
+        return {
+            'CNNRegressor_quick': CNNRegressor(nb_epochs=nb_epochs,
+                                               kernel_size=3,
+                                               avg_pool_size=1),
+            'EncoderRegressor_quick': EncoderRegressor(nb_epochs=nb_epochs),
+            'FCNRegressor_quick': FCNRegressor(nb_epochs=nb_epochs),
+            'LSTMRegressor_quick': LSTMRegressor(nb_epochs=nb_epochs),
+            'MCDCNNRegressor_quick': MCDCNNRegressor(nb_epochs=nb_epochs,
+                                                     dense_units=1),
+            'MLPRegressor_quick': MLPRegressor(nb_epochs=nb_epochs),
+            'ResNetRegressor_quick': ResNetRegressor(nb_epochs=nb_epochs),
+            'TLENETRegressor_quick': TLENETRegressor(nb_epochs=nb_epochs),
+            'InceptionTimeRegressor_quick': InceptionTimeRegressor(
+                nb_epochs=nb_epochs),
+            'SimpleRNNRegressor_quick': SimpleRNNRegressor(
+                nb_epochs=nb_epochs),
+        }
     else:
         # the 'literature-conforming' versions
-        return [
-            CNNRegressor(),
-            EncoderRegressor(),
-            FCNRegressor(),
-            LSTMRegressor(),
-            MCDCNNRegressor(),
-            MLPRegressor(),
-            ResNetRegressor(),
-            TLENETRegressor(),
-            InceptionTimeRegressor(),
-            SimpleRNNRegressor(),
-        ]
+        return {
+            'CNNRegressor': CNNRegressor(),
+            'EncoderRegressor': EncoderRegressor(),
+            'FCNRegressor': FCNRegressor(),
+            'LSTMRegressor': LSTMRegressor(),
+            'MCDCNNRegressor': MCDCNNRegressor(),
+            'MLPRegressor': MLPRegressor(),
+            'ResNetRegressor': ResNetRegressor(),
+            'TLENETRegressor': TLENETRegressor(),
+            'InceptionTimeRegressor': InceptionTimeRegressor(),
+            'SimpleRNNRegressor': SimpleRNNRegressor(),
+        }


### PR DESCRIPTION
**This branch started a while back as a fix for multivariate data handling/cleaning, using one of the newer methods in recent base sktime** 

https://github.com/sktime/sktime-dl/compare/dev...datacleaning?expand=1#diff-eadf622a84d7ec0f0ca9c4996ccdd5d4R104

**This since has also added handling for validation data to fit, in the form of additional arguments.** In the first instance, if the validation data is not None, it shall be predicted after each epoch and the predictions logged in the models history object. 

This is mainly in the interest of e.g. plotting training curves in the future for analysis

Used in this way, i.e. only supplied to fit with no additional change, the validation data has no effect on the resulting model 

However, callbacks can be supplied like EarlyStopping to interact with the validation data to have an effect on the trained model. This has been left as something for the user to externally provide should they want to. It would be up to the user to split their data outside the model and prevent the introduction of bias by e.g. using the test data as the validation and learning from it, via early stopping or otherwise. (This is as opposed to some possible fit parameter validation_split=.33 to split the X data into training/validation sets internally)

tests_validation has been added to test that the supporting networks store the validation predictions correctly

**The model lists used in tests have been changed to dicts over lists, with human-friendly string names.** This is not strictly necessary right now, but in the future it is likely that more instances of the same network are wanted for tests under different parameterisations, which the key can capture for test logging