### PR TITLE
Expose the loss function and optimizer params via model object constructors

### DIFF
--- a/sktime_dl/deeplearning/base/estimators/_classifier.py
+++ b/sktime_dl/deeplearning/base/estimators/_classifier.py
@@ -15,12 +15,18 @@ from sktime_dl.utils import save_trained_model
 
 
 class BaseDeepClassifier(BaseClassifier):
-    def __init__(self, model_name=None, model_save_directory=None):
+    def __init__(self, 
+                 model_name=None, 
+                 model_save_directory=None, 
+                 loss=None, 
+                 optimizer=None):
         self.classes_ = None
         self.nb_classes = None
         self.model_save_directory = model_save_directory
         self.model = None
         self.model_name = model_name
+        self.loss = loss
+        self.optimizer = optimizer
 
     def build_model(self, input_shape, nb_classes, **kwargs):
         """

--- a/sktime_dl/deeplearning/base/estimators/_regressor.py
+++ b/sktime_dl/deeplearning/base/estimators/_regressor.py
@@ -11,10 +11,16 @@ from sktime_dl.utils import save_trained_model
 
 
 class BaseDeepRegressor(BaseRegressor, RegressorMixin):
-    def __init__(self, model_name=None, model_save_directory=None):
+    def __init__(self, 
+                 model_name=None, 
+                 model_save_directory=None,
+                 loss=None, 
+                 optimizer=None):
         self.model_save_directory = model_save_directory
         self.model = None
         self.model_name = model_name
+        self.loss = loss
+        self.optimizer = optimizer
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime_dl/deeplearning/cnn/_classifier.py
+++ b/sktime_dl/deeplearning/cnn/_classifier.py
@@ -47,6 +47,8 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
             avg_pool_size=3,
             nb_conv_layers=2,
             filter_sizes=[6, 12],
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.Adam(),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -55,7 +57,10 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
     ):
         super(CNNClassifier, self).__init__(
             model_save_directory=model_save_directory,
-            model_name=model_name)
+            model_name=model_name,
+            loss=loss,
+            optimizer=optimizer,
+        )
         self.filter_sizes = filter_sizes
         self.nb_conv_layers = nb_conv_layers
         self.avg_pool_size = avg_pool_size
@@ -90,8 +95,8 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
 
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/cnn/_regressor.py
+++ b/sktime_dl/deeplearning/cnn/_regressor.py
@@ -48,6 +48,8 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
             avg_pool_size=3,
             nb_conv_layers=2,
             filter_sizes=[6, 12],
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.Adam(),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -57,6 +59,8 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
         super(CNNRegressor, self).__init__(
             model_save_directory=model_save_directory,
             model_name=model_name,
+            loss=loss,
+            optimizer=optimizer,
         )
         self.filter_sizes = filter_sizes
         self.nb_conv_layers = nb_conv_layers
@@ -87,8 +91,8 @@ class CNNRegressor(BaseDeepRegressor, CNNNetwork):
 
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/encoder/_classifier.py
+++ b/sktime_dl/deeplearning/encoder/_classifier.py
@@ -42,6 +42,8 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
             self,
             nb_epochs=100,
             batch_size=12,
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.Adam(0.00001),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -49,7 +51,10 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
             model_save_directory=None,
     ):
         super(EncoderClassifier, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.nb_epochs = nb_epochs
@@ -83,8 +88,8 @@ class EncoderClassifier(BaseDeepClassifier, EncoderNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.Adam(0.00001),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/encoder/_regressor.py
+++ b/sktime_dl/deeplearning/encoder/_regressor.py
@@ -41,6 +41,8 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
             self,
             nb_epochs=2000,
             batch_size=16,
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.Adam(0.00001),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -48,7 +50,10 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
             model_save_directory=None,
     ):
         super(EncoderRegressor, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -84,8 +89,8 @@ class EncoderRegressor(BaseDeepRegressor, EncoderNetwork):
 
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adam(0.00001),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/fcn/_classifier.py
+++ b/sktime_dl/deeplearning/fcn/_classifier.py
@@ -40,6 +40,8 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
             self,
             nb_epochs=2000,
             batch_size=16,
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.Adam(),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -47,7 +49,10 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
             model_save_directory=None,
     ):
         super(FCNClassifier, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.nb_epochs = nb_epochs
@@ -82,8 +87,8 @@ class FCNClassifier(BaseDeepClassifier, FCNNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/fcn/_regressor.py
+++ b/sktime_dl/deeplearning/fcn/_regressor.py
@@ -39,6 +39,8 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
             self,
             nb_epochs=2000,
             batch_size=16,
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.Adam(),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -46,7 +48,10 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
             model_save_directory=None,
     ):
         super(FCNRegressor, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -83,8 +88,8 @@ class FCNRegressor(BaseDeepRegressor, FCNNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/inceptiontime/_classifier.py
+++ b/sktime_dl/deeplearning/inceptiontime/_classifier.py
@@ -53,6 +53,8 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
             kernel_size=41 - 1,
             batch_size=64,
             nb_epochs=1500,
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.Adam(),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -60,7 +62,10 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
             model_save_directory=None,
     ):
         super(InceptionTimeClassifier, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -103,8 +108,8 @@ class InceptionTimeClassifier(BaseDeepClassifier, InceptionTimeNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/inceptiontime/_regressor.py
+++ b/sktime_dl/deeplearning/inceptiontime/_regressor.py
@@ -55,6 +55,8 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
             kernel_size=41 - 1,
             batch_size=64,
             nb_epochs=1500,
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.Adam(),
             callbacks=None,
             random_state=0,
             verbose=False,
@@ -62,7 +64,10 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
             model_save_directory=None,
     ):
         super(InceptionTimeRegressor, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -101,8 +106,8 @@ class InceptionTimeRegressor(BaseDeepRegressor, InceptionTimeNetwork):
 
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/lstm/_regressor.py
+++ b/sktime_dl/deeplearning/lstm/_regressor.py
@@ -21,6 +21,8 @@ class LSTMRegressor(BaseDeepRegressor, LSTMNetwork):
             nb_epochs=200,
             batch_size=16,
             units=[50, 50],
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.Adam(),
             random_state=0,
             verbose=False,
             model_name="lstm_regressor",
@@ -34,7 +36,9 @@ class LSTMRegressor(BaseDeepRegressor, LSTMNetwork):
         """
         super(LSTMRegressor, self).__init__(
             model_save_directory=model_save_directory,
-            model_name=model_name
+            model_name=model_name,
+            loss=loss,
+            optimizer=optimizer,
         )
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
@@ -59,8 +63,8 @@ class LSTMRegressor(BaseDeepRegressor, LSTMNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss='mean_squared_error',
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=['mean_squared_error'])
         return model
 

--- a/sktime_dl/deeplearning/mcdcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcdcnn/_classifier.py
@@ -40,6 +40,10 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
             pool_size=2,
             filter_sizes=[8, 8],
             dense_units=732,
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.SGD(
+                lr=0.01, momentum=0.9, decay=0.0005
+            ),
             callbacks=[],
             random_state=0,
             verbose=False,
@@ -64,7 +68,10 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
         the trained keras model in hdf5 format
         """
         super(MCDCNNClassifier, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -114,10 +121,8 @@ class MCDCNNClassifier(BaseDeepClassifier, MCDCNNNetwork):
         model = keras.models.Model(inputs=input_layers, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.SGD(
-                lr=0.01, momentum=0.9, decay=0.0005
-            ),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/mcdcnn/_regressor.py
+++ b/sktime_dl/deeplearning/mcdcnn/_regressor.py
@@ -32,6 +32,10 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
             pool_size=2,
             filter_sizes=[8, 8],
             dense_units=732,
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.SGD(
+                lr=0.01, momentum=0.9, decay=0.0005
+            ),
             callbacks=[],
             random_state=0,
             verbose=False,
@@ -56,7 +60,10 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
          trained keras model in hdf5 format
         """
         super(MCDCNNRegressor, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -98,10 +105,8 @@ class MCDCNNRegressor(BaseDeepRegressor, MCDCNNNetwork):
         model = keras.models.Model(inputs=input_layers, outputs=output_layer)
 
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.SGD(
-                lr=0.01, momentum=0.9, decay=0.0005
-            ),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/mcnn/_classifier.py
+++ b/sktime_dl/deeplearning/mcnn/_classifier.py
@@ -43,6 +43,8 @@ class MCNNClassifier(BaseDeepClassifier):
             nb_epochs=200,
             max_train_batch_size=256,
             slice_ratio=0.9,
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.Adam(lr=0.1),
             random_state=0,
             verbose=False,
             model_name="mcnn",
@@ -66,7 +68,9 @@ class MCNNClassifier(BaseDeepClassifier):
         """
         super(MCNNClassifier, self).__init__(
             model_save_directory=model_save_directory,
-            model_name=model_name
+            model_name=model_name,
+            loss=loss,
+            optimizer=optimizer,
         )
         self.random_state = random_state
         self.verbose = verbose
@@ -494,8 +498,8 @@ class MCNNClassifier(BaseDeepClassifier):
         model = keras.models.Model(inputs=input_layers, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.Adam(lr=0.1),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/mlp/_classifier.py
+++ b/sktime_dl/deeplearning/mlp/_classifier.py
@@ -28,6 +28,8 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
     def __init__(self,
                  nb_epochs=5000,
                  batch_size=16,
+                 loss="categorical_crossentropy",
+                 optimizer=keras.optimizers.Adadelta(),
                  callbacks=None,
                  random_state=0,
                  verbose=False,
@@ -47,7 +49,9 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
         """
         super(MLPClassifier, self).__init__(
             model_save_directory=model_save_directory,
-            model_name=model_name
+            model_name=model_name,
+            loss=loss,
+            optimizer=optimizer,
         )
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
@@ -79,8 +83,8 @@ class MLPClassifier(BaseDeepClassifier, MLPNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.Adadelta(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/mlp/_regressor.py
+++ b/sktime_dl/deeplearning/mlp/_regressor.py
@@ -32,6 +32,8 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
     def __init__(self,
                  nb_epochs=2000,
                  batch_size=16,
+                 loss="mean_squared_error",
+                 optimizer=keras.optimizers.Adadelta(),
                  callbacks=None,
                  random_state=0,
                  verbose=False,
@@ -50,7 +52,9 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
         """
         super(MLPRegressor, self).__init__(
             model_save_directory=model_save_directory,
-            model_name=model_name
+            model_name=model_name,
+            loss=loss,
+            optimizer=optimizer,
         )
         self.verbose = verbose
         self._is_fitted = False
@@ -84,8 +88,8 @@ class MLPRegressor(BaseDeepRegressor, MLPNetwork):
 
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adadelta(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/resnet/_classifier.py
+++ b/sktime_dl/deeplearning/resnet/_classifier.py
@@ -34,6 +34,8 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
                  nb_epochs=1500,
                  batch_size=16,
                  callbacks=None,
+                 loss="categorical_crossentropy",
+                 optimizer=keras.optimizers.Adam(),
                  random_state=0,
                  verbose=False,
                  model_name="resnet",
@@ -52,7 +54,10 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         """
 
         super(ResNetClassifier, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.verbose = verbose
@@ -94,8 +99,8 @@ class ResNetClassifier(BaseDeepClassifier, ResNetNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="categorical_crossentropy",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/resnet/_regressor.py
+++ b/sktime_dl/deeplearning/resnet/_regressor.py
@@ -27,6 +27,8 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
     def __init__(self,
                  nb_epochs=1500,
                  batch_size=16,
+                 loss="mean_squared_error",
+                 optimizer=keras.optimizers.Adam(),
                  callbacks=None,
                  random_state=0,
                  verbose=False,
@@ -46,7 +48,10 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         """
 
         super(ResNetRegressor, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
         self.nb_epochs = nb_epochs
@@ -78,8 +83,8 @@ class ResNetRegressor(BaseDeepRegressor, ResNetNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            loss="mean_squared_error",
-            optimizer=keras.optimizers.Adam(),
+            loss=self.loss,
+            optimizer=self.optimizer,
             metrics=["mean_squared_error"],
         )
 

--- a/sktime_dl/deeplearning/rnn/_regressor.py
+++ b/sktime_dl/deeplearning/rnn/_regressor.py
@@ -30,6 +30,8 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
             nb_epochs=100,
             batch_size=1,
             units=6,
+            loss="mean_squared_error",
+            optimizer=RMSprop(lr=0.001),
             callbacks=None,
             random_state=0,
             verbose=0,
@@ -44,7 +46,9 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
         self.random_state = random_state
         super(SimpleRNNRegressor, self).__init__(
             model_name=model_name,
-            model_save_directory=model_save_directory
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
 
     def build_model(self, input_shape, **kwargs):
@@ -64,7 +68,7 @@ class SimpleRNNRegressor(BaseDeepRegressor, BaseDeepNetwork):
                 Dense(1, use_bias=True, activation="linear"),
             ]
         )
-        model.compile(loss="mean_squared_error", optimizer=RMSprop(lr=0.001))
+        model.compile(loss=self.loss, optimizer=self.optimizer)
 
         if self.callbacks is None:
             self.callbacks = []

--- a/sktime_dl/deeplearning/tlenet/_classifier.py
+++ b/sktime_dl/deeplearning/tlenet/_classifier.py
@@ -35,6 +35,8 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
             batch_size=256,
             warping_ratios=[0.5, 1, 2],
             slice_ratio=0.1,
+            loss="categorical_crossentropy",
+            optimizer=keras.optimizers.Adam(lr=0.01, decay=0.005),
             callbacks=None,
             verbose=False,
             random_state=0,
@@ -57,7 +59,10 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
          the trained keras model in hdf5 format
         """
         super(TLENETClassifier, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
         )
         self.nb_epochs = nb_epochs
         self.batch_size = batch_size
@@ -92,8 +97,8 @@ class TLENETClassifier(BaseDeepClassifier, TLENETNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            optimizer=keras.optimizers.Adam(lr=0.01, decay=0.005),
-            loss="categorical_crossentropy",
+            optimizer=self.optimizer,
+            loss=self.loss,
             metrics=["accuracy"],
         )
 

--- a/sktime_dl/deeplearning/tlenet/_regressor.py
+++ b/sktime_dl/deeplearning/tlenet/_regressor.py
@@ -31,6 +31,8 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
             batch_size=256,
             warping_ratios=[0.5, 1, 2],
             slice_ratio=0.1,
+            loss="mean_squared_error",
+            optimizer=keras.optimizers.Adam(lr=0.01, decay=0.005),
             callbacks=None,
             verbose=False,
             random_state=0,
@@ -53,7 +55,11 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
          the trained keras model in hdf5 format
         """
         super(TLENETRegressor, self).__init__(
-            model_name=model_name, model_save_directory=model_save_directory)
+            model_name=model_name,
+            model_save_directory=model_save_directory,
+            loss=loss,
+            optimizer=optimizer,
+        )
 
         self.verbose = verbose
         self._is_fitted = False
@@ -88,8 +94,8 @@ class TLENETRegressor(BaseDeepRegressor, TLENETNetwork):
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
 
         model.compile(
-            optimizer=keras.optimizers.Adam(lr=0.01, decay=0.005),
-            loss="mean_squared_error",
+            optimizer=self.optimizer,
+            loss=self.loss,
             metrics=["mean_squared_error"],
         )
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #73. 

#### What does this implement/fix? Explain your changes.

- changed default loss function of CNNClassifier to `categorical_crossentropy`
- exposed the loss function and optimizer parameters in model constructors so that the users can e.g. tune the initial learning rate of the model through the package API
