### PR TITLE
sktime compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The simplest installation method is to install in a new environment via pip:
 	
 	pip install sktime-dl
 	
-sktime-dl is under development. To ensure that you're using the most up to date code, you can instead install the development version in your environment: 
+sktime-dl is under development. To ensure that you're using the most up to date code, you can instead download the code from Github and install it in your environment:
 ::
 	git clone https://github.com/sktime/sktime-dl.git
 	cd sktime-dl

--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,6 @@ sktime-dl is under development. To ensure that you're using the most up to date 
 ::
 	git clone https://github.com/sktime/sktime-dl.git
 	cd sktime-dl
-	git checkout dev
-	git pull origin dev
 	pip install . 
 	
 When installing sktime-dl from scratch, the latest stable version of 

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,4 +1,4 @@
-sktime>=0.4.1
+sktime==0.4.1
 tensorflow>=1.9
 tensorflow_addons==0.9.*
 h5py

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def find_install_requires():
     """
 
     install_requires = [
-        'sktime>=0.4.1',
+        'sktime==0.4.1',
         'h5py>=2.8.0',
     ]
 


### PR DESCRIPTION
Fixes #76. See also #74.

#### What does this implement/fix? Explain your changes.
Changed requirement to sktime==0.4.1 where it was previously sktime>=0.4.1 .
This resolves the issue of incompatibility with later versions of sktime.
Updated the readme to suggest that users download code from the master branch, not the dev branch.

#### Any other comments?
Tested by: 
+ following the readme doc instructions to git clone and install the code. Built and tested a CNNClassifier.
+ following the Docker instructions in the readme doc and running the test suite.
