### PR TITLE
modified the loss function for _cnn.py

### DIFF
--- a/sktime_dl/classification/_cnn.py
+++ b/sktime_dl/classification/_cnn.py
@@ -97,7 +97,7 @@ class CNNClassifier(BaseDeepClassifier, CNNNetwork):
 
         model = keras.models.Model(inputs=input_layer, outputs=output_layer)
         model.compile(
-            loss="mean_squared_error",
+            loss=keras.losses.BinaryCrossentropy(),
             optimizer=keras.optimizers.Adam(),
             metrics=["accuracy"],
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the extension guidelines: https://github.com/sktime/sktime-dl/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Not an issue fix

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. 
-->
I have modified the loss function of the `_cnn.py` file. The current loss function for the `_cnn.py` file which is used to classify between two classes is `RMSE` but the appropriate loss function for training a model for binary classification is `binary_crossentrophy`. This loss function can significantly improve the training  and performance of the estimator.
#### Does your contribution introduce a new dependency? If yes, which one? 

<!--
If your contribution does add a new dependency, we may suggest to initially develop your contribution in a separate
 companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum. 
-->
No

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
No