### PR TITLE
Don't refit onehot_encoder for validation data

### DIFF
--- a/sktime_dl/utils/_data.py
+++ b/sktime_dl/utils/_data.py
@@ -81,7 +81,7 @@ def check_and_clean_validation_data(validation_X, validation_y,
         validation_y = label_encoder.transform(validation_y)
         validation_y = validation_y.reshape(
             len(validation_y), 1)
-        validation_y = onehot_encoder.fit_transform(
+        validation_y = onehot_encoder.transform(
             validation_y)
 
     return (validation_X, validation_y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes sktime/sktime#5864 

#### What does this implement/fix? Explain your changes.
Currently, this leads to a bug when validation data has fewer classes
than the training data since the onehot_encoder will be fit to the
validation data categories.

#### Does your contribution introduce a new dependency? If yes, which one? 
No new dependency